### PR TITLE
[feat] 사용자 Entity, DTO 작성 및 DB 포트 설정

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - POSTGRES_USER=${DB_USERNAME}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - monew-postgres-data:/var/lib/postgresql/data
       - ./src/main/resources/schema-postgre.sql:/docker-entrypoint-initdb.d/init-schema.sql:ro
@@ -68,12 +68,14 @@ services:
       - "27017:27017"
     volumes:
       - monew-mongodb-data:/data/db
+      - monew-mongodb-config:/data/configdb
     networks:
       - monew-network
 
 volumes:
   monew-postgres-data: # RDS로 전환 시 볼륨도 필요없으므로 주석 처리 또는 삭제하세요.
   monew-mongodb-data:
+  monew-mongodb-config:
 
 networks:
   monew-network:

--- a/src/main/java/com/codeit/monew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/codeit/monew/domain/user/dto/UserDto.java
@@ -1,0 +1,13 @@
+package com.codeit.monew.domain.user.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserDto(
+    UUID id,
+    String email,
+    String nickname,
+    Instant createdAt
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/com/codeit/monew/domain/user/dto/UserLoginRequest.java
@@ -1,0 +1,16 @@
+package com.codeit.monew.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserLoginRequest(
+    @Email
+    @NotBlank
+    String email,
+    @Size(min = 6, max = 20)
+    @NotBlank
+    String password
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/codeit/monew/domain/user/dto/UserRegisterRequest.java
@@ -1,0 +1,19 @@
+package com.codeit.monew.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserRegisterRequest(
+    @Email
+    @NotBlank
+    String email,
+    @Size(min = 1, max = 20)
+    @NotBlank
+    String nickname,
+    @Size(min = 6, max = 20)
+    @NotBlank
+    String password
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/codeit/monew/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserUpdateRequest(
+    @Size(min = 1, max = 20)
+    @NotBlank
+    String nickname
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/user/entity/User.java
+++ b/src/main/java/com/codeit/monew/domain/user/entity/User.java
@@ -1,0 +1,63 @@
+package com.codeit.monew.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Getter
+@Table(name = "users")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @LastModifiedDate
+  private Instant updatedAt;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  private String nickname;
+
+  @Column(nullable = false)
+  private String password;
+
+  private Instant deletedAt;
+
+  public User(String email, String nickname, String password) {
+    this.email = email;
+    this.nickname = nickname;
+    this.password = password;
+  }
+
+  public void updateNickname(String nickname) {
+    if (nickname != null && !nickname.equals(this.nickname)) {
+      this.nickname = nickname;
+    }
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
+  }
+}

--- a/src/main/java/com/codeit/monew/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/codeit/monew/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.codeit.monew.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
resolves: #1, #17, #18, #27

## 📝작업 내용
사용자 엔티티, DTO 클래스 작성하였습니다.
개발 환경에서 PostgreSQL 컨테이너 연결 포트를 5433으로 변경하였습니다.
MongoDB 설정에 대한 볼륨을 추가하였습니다. (monew-mongodb-config)

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)
.env는 디스코드로 공유하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 사용자 인증 및 회원가입 기능이 추가되었습니다.
  * 사용자 프로필 업데이트 기능이 추가되었습니다.

* **Chores**
  * PostgreSQL 데이터베이스 접근 포트가 변경되었습니다.
  * MongoDB 설정 데이터베이스 스토리지가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->