### PR TITLE
[feat] 관심사 등록 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Levenshtein Distance(유사도 검증 알고리즘)
+    implementation 'org.apache.commons:commons-text:1.11.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
@@ -1,0 +1,31 @@
+package com.codeit.monew.domain.interest.controller;
+
+import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
+import com.codeit.monew.domain.interest.dto.response.InterestDto;
+import com.codeit.monew.domain.interest.service.InterestService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/interests")
+@RequiredArgsConstructor
+public class InterestController {
+
+  private final InterestService interestService;
+
+  // 1. 관심사 등록
+  @PostMapping
+  public ResponseEntity<InterestDto> register(
+      @RequestBody @Valid InterestRegisterRequest request
+  ) {
+    InterestDto response = interestService.register(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestRegisterRequest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestRegisterRequest.java
@@ -1,0 +1,16 @@
+package com.codeit.monew.domain.interest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record InterestRegisterRequest(
+    @NotBlank
+    @Size(max = 50)
+    String name,
+
+    @NotEmpty
+    @Size(max = 10)
+    List<@NotBlank String> keywords
+) {}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
@@ -2,9 +2,11 @@ package com.codeit.monew.domain.interest.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record InterestUpdateRequest(
     @NotEmpty
+    @Size(max = 10)
     List<@NotBlank String> keywords
 ) {}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.codeit.monew.domain.interest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record InterestUpdateRequest(
+    @NotEmpty
+    List<@NotBlank String> keywords
+) {}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -1,0 +1,13 @@
+package com.codeit.monew.domain.interest.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CursorPageResponseInterestDto(
+    List<InterestDto> content,
+    String nextCursor,
+    LocalDateTime nextAfter,
+    int size,
+    long totalElements,
+    boolean hasNext
+) {}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/InterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/InterestDto.java
@@ -1,0 +1,41 @@
+package com.codeit.monew.domain.interest.dto.response;
+
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.interest.entity.Keyword;
+import java.util.List;
+import java.util.UUID;
+
+// 관심사 응답
+public record InterestDto(
+    UUID id,
+    String name,
+    List<String> keywords,
+    long subscriberCount,
+    boolean subscribedByMe
+) {
+  // 등록 시 사용
+  public static InterestDto from(Interest interest) {
+    return new InterestDto(
+        interest.getId(),
+        interest.getName(),
+        interest.getKeywords().stream()
+            .map(Keyword::getName)
+            .toList(),
+        interest.getSubscriberCount(),
+        false
+    );
+  }
+
+  // 목록 조회 시 사용
+  public static InterestDto from(Interest interest, boolean subscribedByMe) {
+    return new InterestDto(
+        interest.getId(),
+        interest.getName(),
+        interest.getKeywords().stream()
+            .map(Keyword::getName)
+            .toList(),
+        interest.getSubscriberCount(),
+        subscribedByMe
+    );
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/SubscriptionDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/SubscriptionDto.java
@@ -1,0 +1,31 @@
+package com.codeit.monew.domain.interest.dto.response;
+
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.interest.entity.Keyword;
+import com.codeit.monew.domain.interest.entity.Subscription;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record SubscriptionDto (
+    UUID id,
+    UUID interestId,
+    String interestName,
+    List<String> interestKeywords,
+    long interestSubscriberCount,
+    LocalDateTime createdAt
+) {
+  public static SubscriptionDto from(Subscription subscription) {
+    Interest interest = subscription.getInterest();
+    return new SubscriptionDto(
+        subscription.getId(),
+        interest.getId(),
+        interest.getName(),
+        interest.getKeywords().stream()
+            .map(Keyword::getName)
+            .toList(),
+        interest.getSubscriberCount(),
+        subscription.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
@@ -1,14 +1,17 @@
 package com.codeit.monew.domain.interest.repository;
 
 import com.codeit.monew.domain.interest.entity.Interest;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID> {
 
   // 유사도 검사용 전체 이름 조회
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT i.name FROM Interest i")
-  List<String> findAllNames();
+  List<String> findAllNamesWithLock();
 }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
@@ -1,0 +1,14 @@
+package com.codeit.monew.domain.interest.repository;
+
+import com.codeit.monew.domain.interest.entity.Interest;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface InterestRepository extends JpaRepository<Interest, UUID> {
+
+  // 유사도 검사용 전체 이름 조회
+  @Query("SELECT i.name FROM Interest i")
+  List<String> findAllNames();
+}

--- a/src/main/java/com/codeit/monew/domain/interest/repository/KeywordRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/KeywordRepository.java
@@ -1,0 +1,11 @@
+package com.codeit.monew.domain.interest.repository;
+
+import com.codeit.monew.domain.interest.entity.Keyword;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeywordRepository extends JpaRepository<Keyword, UUID> {
+
+  // 관심사 수정 시 기존 키워드 전체 삭제용
+  void deleteAllByInterestId(UUID interestId);
+}

--- a/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
@@ -1,0 +1,15 @@
+package com.codeit.monew.domain.interest.repository;
+
+import com.codeit.monew.domain.interest.entity.Subscription;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+
+  // 중복 구독 확인용
+  boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+  // 구독 취소용
+  void deleteByUserIdAndInterestId(UUID userId, UUID interestId);
+
+}

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -24,7 +24,7 @@ public class InterestService {
   public InterestDto register(InterestRegisterRequest request) {
 
     // 유사도 검사
-    List<String> existingNames = interestRepository.findAllNames();
+    List<String> existingNames = interestRepository.findAllNamesWithLock();
     for (String existingName : existingNames) {
       // 추후 공통 예외 클래스 생기면 커스텀 예외로 교체 예정 !!
       if (calculateSimilarity(request.name(), existingName) >= 0.8) {

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -1,0 +1,58 @@
+package com.codeit.monew.domain.interest.service;
+
+import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
+import com.codeit.monew.domain.interest.dto.response.InterestDto;
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.interest.entity.Keyword;
+import com.codeit.monew.domain.interest.repository.InterestRepository;
+import com.codeit.monew.domain.interest.repository.KeywordRepository;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterestService {
+
+  private final InterestRepository interestRepository;
+  private final KeywordRepository keywordRepository;
+
+  @Transactional
+  public InterestDto register(InterestRegisterRequest request) {
+
+    // 유사도 검사
+    List<String> existingNames = interestRepository.findAllNames();
+    for (String existingName : existingNames) {
+      // 추후 공통 예외 클래스 생기면 커스텀 예외로 교체 예정 !!
+      if (calculateSimilarity(request.name(), existingName) >= 0.8) {
+        throw new IllegalArgumentException("유사한 관심사가 이미 존재합니다: " + existingName);
+      }
+    }
+
+    // 관심사 저장
+    Interest interest = Interest.create(request.name());
+    interestRepository.save(interest);
+
+    // 키워드 저장
+    List<Keyword> keywords = request.keywords().stream()
+        .map(name -> Keyword.create(interest, name))
+        .toList();
+
+    interest.getKeywords().addAll(keywords);
+
+    return InterestDto.from(interest);
+  }
+
+  private double calculateSimilarity(String a, String b) {
+    a = a.toLowerCase();
+    b = b.toLowerCase();
+    LevenshteinDistance ld = new LevenshteinDistance();
+    int distance = ld.apply(a, b);
+    int maxLen = Math.max(a.length(), b.length());
+    if (maxLen == 0) return 1.0;
+    return 1.0 - ((double) distance / maxLen);
+  }
+}

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
 -- 관심사 table
 CREATE TABLE IF NOT EXISTS interests (
     id               UUID PRIMARY KEY,
-    name             VARCHAR(50)              NOT NULL,
+    name             VARCHAR(50)              NOT NULL UNIQUE,
     subscriber_count BIGINT                   NOT NULL DEFAULT 0,
     created_at       TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/src/main/resources/schema-postgre.sql
+++ b/src/main/resources/schema-postgre.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS users (
 -- 관심사 table
 CREATE TABLE IF NOT EXISTS interests (
     id               UUID PRIMARY KEY,
-    name             VARCHAR(50) NOT NULL,
+    name             VARCHAR(50) NOT NULL UNIQUE,
     subscriber_count BIGINT      NOT NULL DEFAULT 0,
     created_at       TIMESTAMPTZ NOT NULL
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE users
 CREATE TABLE interests
 (
     id               UUID PRIMARY KEY,
-    name             VARCHAR(50) NOT NULL,
+    name             VARCHAR(50) NOT NULL UNIQUE,
     subscriber_count BIGINT      NOT NULL DEFAULT 0,
     created_at       TIMESTAMPTZ NOT NULL
 );


### PR DESCRIPTION
## #️⃣연관된 이슈
#3 #5 #7 

## 📝작업 내용
- 관심사 Response 및 Request DTO 설계
- 관심사 등록 Repository 설계
- 관심사 등록 Controller 설계
- 관심사 등록 Service 설계

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관심사 등록 API 추가 — 이름(최대 50자)과 키워드(최대 10개)로 등록 가능
  * 등록 시 유효성 검사(빈값/길이) 적용

* **개선**
  * 유사도 검증으로 유사한 관심사 중복 등록 방지
  * 관심사 목록 조회에 커서 기반 페이지네이션 지원

* **데이터베이스**
  * 관심사 이름에 고유 제약조건(중복 방지) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->