### PR TITLE
[feat] 뉴스 기사 출처 목록 조회 기능 구현 및 예외 처리 추가

### DIFF
--- a/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
@@ -1,15 +1,18 @@
 package com.codeit.monew.domain.article.controller;
 
 import com.codeit.monew.domain.article.dto.ArticleDto;
+import com.codeit.monew.domain.article.ArticleSource;
 import com.codeit.monew.domain.article.service.ArticleService;
 import com.codeit.monew.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,6 +35,7 @@ public class ArticleController {
   @Operation(summary = "뉴스 기사 단건 조회", description = "뉴스 기사 ID로 뉴스 기사 단건을 조회합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ArticleDto.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 필수 헤더 누락", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "사용자 또는 뉴스 기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
@@ -40,6 +44,18 @@ public class ArticleController {
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
   ) {
     ArticleDto response = articleService.getArticle(articleId, requestUserId);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @GetMapping(value = "/sources")
+  @Operation(summary = "출처 목록 조회", description = "출처 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ArticleSource.class)))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<List<ArticleSource>> getSources() {
+    List<ArticleSource> response = articleService.getSources();
 
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }

--- a/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
@@ -1,11 +1,17 @@
 package com.codeit.monew.domain.article.repository;
 
+import com.codeit.monew.domain.article.ArticleSource;
 import com.codeit.monew.domain.article.entity.Article;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleRepository extends JpaRepository<Article, UUID> {
 
   Optional<Article> findByIdAndDeletedAtIsNull(UUID id);
+
+  @Query("SELECT DISTINCT source FROM Article ORDER BY source ASC ")
+  List<ArticleSource> findDistinctSource();
 }

--- a/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
@@ -12,6 +12,6 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
 
   Optional<Article> findByIdAndDeletedAtIsNull(UUID id);
 
-  @Query("SELECT DISTINCT source FROM Article ORDER BY source ASC ")
+  @Query("SELECT DISTINCT a.source FROM Article AS a WHERE a.deletedAt IS NULL ORDER BY a.source ASC ")
   List<ArticleSource> findDistinctSource();
 }

--- a/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
@@ -59,7 +59,6 @@ public class ArticleService {
   // 뉴스 기사 출처 목록 조회
   @Transactional(readOnly = true)
   public List<ArticleSource> getSources() {
-
     return articleRepository.findDistinctSource();
   }
 }

--- a/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
@@ -1,5 +1,6 @@
 package com.codeit.monew.domain.article.service;
 
+import com.codeit.monew.domain.article.ArticleSource;
 import com.codeit.monew.domain.article.dto.ArticleDto;
 import com.codeit.monew.domain.article.entity.Article;
 import com.codeit.monew.domain.article.mapper.ArticleMapper;
@@ -9,6 +10,7 @@ import com.codeit.monew.domain.comment.repository.CommentRepository;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,5 +54,12 @@ public class ArticleService {
         articleId, article.getTitle(), article.getPublishDate(), article.getCreatedAt());
 
     return articleMapper.toDto(article, commentCount, viewCount, viewedByMe);
+  }
+
+  // 뉴스 기사 출처 목록 조회
+  @Transactional(readOnly = true)
+  public List<ArticleSource> getSources() {
+
+    return articleRepository.findDistinctSource();
   }
 }

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -14,10 +14,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.View;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  private final View error;
+
+  public GlobalExceptionHandler(View error) {
+    this.error = error;
+  }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
@@ -54,10 +61,11 @@ public class GlobalExceptionHandler {
         e.getMessage(), e);
 
     Map<String, Object> details = new HashMap<>();
-    e.getBindingResult().getAllErrors().forEach(error -> {
-      String fieldName = ((FieldError) error).getField();
-      String errorMessage = error.getDefaultMessage();
-      details.put(fieldName, errorMessage);
+    e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+      details.put(fieldError.getField(), fieldError.getDefaultMessage());
+    });
+    e.getBindingResult().getGlobalErrors().forEach(fieldError -> {
+      details.put(fieldError.getObjectName(), fieldError.getDefaultMessage());
     });
 
     ErrorResponse response = new ErrorResponse(

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -8,10 +8,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -19,7 +21,8 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
-    log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
+    log.error("[Exception] 예상하지 못한 예외: code={}, message={}", e.getClass().getSimpleName(),
+        e.getMessage(), e);
     ErrorResponse errorResponse = new ErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR.value());
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -27,11 +30,18 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(MonewException.class)
-  public ResponseEntity<ErrorResponse> handleMonewException(MonewException exception) {
-    log.error("커스텀 예외 발생: code={}, message={}", exception.getErrorCode(), exception.getMessage(),
-        exception);
-    HttpStatus status = determineHttpStatus(exception);
-    ErrorResponse response = new ErrorResponse(exception, status.value());
+  public ResponseEntity<ErrorResponse> handleMonewException(MonewException e) {
+    HttpStatus status = determineHttpStatus(e);
+
+    if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
+      log.error("[Exception] 커스텀 예외: timestamp={}, code={}, message={}, details={}",
+          e.getTimestamp(), e.getErrorCode().name(), e.getMessage(), e.getDetails(), e);
+    } else {
+      log.warn("[Exception] 커스텀 예외: timestamp={}, code={}, message={}, details={}",
+          e.getTimestamp(), e.getErrorCode().name(), e.getMessage(), e.getDetails(), e);
+    }
+
+    ErrorResponse response = new ErrorResponse(e, status.value());
     return ResponseEntity
         .status(status)
         .body(response);
@@ -39,28 +49,69 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleValidationExceptions(
-      MethodArgumentNotValidException ex) {
-    log.error("요청 유효성 검사 실패: {}", ex.getMessage());
+      MethodArgumentNotValidException e) {
+    log.warn("[EXCEPTION] Bean Validation 예외: code={}, message={}", e.getClass().getSimpleName(),
+        e.getMessage(), e);
 
-    Map<String, Object> validationErrors = new HashMap<>();
-    ex.getBindingResult().getAllErrors().forEach(error -> {
+    Map<String, Object> details = new HashMap<>();
+    e.getBindingResult().getAllErrors().forEach(error -> {
       String fieldName = ((FieldError) error).getField();
       String errorMessage = error.getDefaultMessage();
-      validationErrors.put(fieldName, errorMessage);
+      details.put(fieldName, errorMessage);
     });
 
     ErrorResponse response = new ErrorResponse(
         Instant.now(),
         "VALIDATION_ERROR",
         "요청 데이터 유효성 검사에 실패했습니다",
-        validationErrors,
-        ex.getClass().getSimpleName(),
+        details,
+        e.getClass().getSimpleName(),
         HttpStatus.BAD_REQUEST.value()
     );
 
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
         .body(response);
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<ErrorResponse> handleException(MissingRequestHeaderException e) {
+    log.warn("[EXCEPTION] 필수 헤더 누락 예외: code={}, header={}, message={}",
+        e.getClass().getSimpleName(), e.getHeaderName(), e.getMessage());
+
+    Map<String, Object> details = new HashMap<>();
+    details.put("headerName", e.getHeaderName());
+
+    ErrorResponse errorResponse = new ErrorResponse(
+        Instant.now(),
+        "MISSING_REQUEST_HEADER",
+        "필수 요청 헤더가 누락되었습니다.",
+        details,
+        e.getClass().getSimpleName(),
+        HttpStatus.BAD_REQUEST.value()
+    );
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleException(MethodArgumentTypeMismatchException e) {
+    log.warn("[EXCEPTION] 요청 파라미터 형식 예외: code={}, message={}", e.getClass().getSimpleName(),
+        e.getMessage(), e);
+
+    Map<String, Object> details = new HashMap<>();
+    details.put(e.getName(), e.getValue()); // (파라미터 필드 이름, 파라미터 필드 값)
+
+    ErrorResponse errorResponse = new ErrorResponse(
+        Instant.now(),
+        "INVALID_PARAMETER_TYPE",
+        "요청 파라미터 형식이 올바르지 않습니다.",
+        details,
+        e.getClass().getSimpleName(),
+        HttpStatus.BAD_REQUEST.value()
+    );
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
   }
 
   private HttpStatus determineHttpStatus(MonewException exception) {

--- a/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
@@ -1,10 +1,11 @@
 package com.codeit.monew.domain.article.controller;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import com.codeit.monew.domain.article.dto.ArticleDto;
-import com.codeit.monew.domain.article.entity.ArticleSource;
+import com.codeit.monew.domain.article.ArticleSource;
 import com.codeit.monew.domain.article.service.ArticleService;
 import com.codeit.monew.global.exception.ErrorCode;
 import com.codeit.monew.global.exception.GlobalExceptionHandler;
@@ -12,6 +13,7 @@ import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -64,7 +65,7 @@ class ArticleControllerTest {
       UUID requestUserId = UUID.randomUUID();
       UUID articleId = UUID.randomUUID();
       ArticleDto articleDto = createArticleDto(articleId, ArticleSource.NAVER, "https://naver.com",
-          "테스트title", Instant.now(), "테스트summary", 5, 6, true);
+          "testTitle", Instant.now(), "testSummary", 5, 6, true);
 
       given(articleService.getArticle(articleId, requestUserId)).willReturn(articleDto);
 
@@ -115,6 +116,29 @@ class ArticleControllerTest {
           .andExpect(
               jsonPath("$.exceptionType").value(ArticleNotFoundException.class.getSimpleName()))
           .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스 기사 출처 목록 조회 API 테스트")
+  class getSource {
+
+    @Test
+    @DisplayName("뉴스 기사 출처 목록 조회하면 200 상태코드와 DB에 저장된 뉴스 기사의 출처 목록이 반환된다.")
+    void success_get_article_source() throws Exception {
+      // given(준비)
+      List<ArticleSource> sources = List.of(ArticleSource.HANKYUNG, ArticleSource.NAVER,
+          ArticleSource.YEONHAP);
+
+      given(articleService.getSources()).willReturn(sources);
+
+      // when(실행), then(검증)
+      mockMvc.perform(get("/api/articles/sources"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$", hasSize(3)))
+          .andExpect(jsonPath("$[0]").value(ArticleSource.HANKYUNG.toString()))
+          .andExpect(jsonPath("$[1]").value(ArticleSource.NAVER.toString()))
+          .andExpect(jsonPath("$[2]").value(ArticleSource.YEONHAP.toString()));
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/repository/ArticleRepositoryTest.java
@@ -1,0 +1,68 @@
+package com.codeit.monew.domain.article.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.codeit.monew.domain.article.ArticleSource;
+import com.codeit.monew.domain.article.entity.Article;
+import com.codeit.monew.global.config.JpaAuditingConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaAuditingConfig.class)
+class ArticleRepositoryTest {
+
+  @Autowired
+  private ArticleRepository articleRepository;
+
+  @Autowired
+  private TestEntityManager testEntityManager;
+
+  @BeforeEach
+  void setUp() {
+    articleRepository.deleteAll();
+  }
+
+  private Article createArticle(ArticleSource source, String sourceUrl,
+      String title, Instant publishDate, String summary) {
+    Article article = Article.createArticle(source, sourceUrl, title, publishDate, summary);
+
+    return articleRepository.save(article);
+  }
+
+  @Test
+  @DisplayName("저장된 뉴스 기사의 출처 목록을 중복 없이 조회할 수 있다.")
+  void findDistinctSource() {
+    // given(준비)
+    Article article1 = createArticle(ArticleSource.NAVER, "https://naver1.com", "title1",
+        Instant.now(), "summary1");
+    Article article2 = createArticle(ArticleSource.NAVER, "https://naver2.com", "title2",
+        Instant.now(), "summary2");
+    Article article3 = createArticle(ArticleSource.CHOSUN, "https://chosun1.com", "title3",
+        Instant.now(), "summary3");
+
+    // 영속성 해제
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    // when(실행)
+    List<ArticleSource> result = articleRepository.findDistinctSource();
+
+    // then(검증)
+    assertThat(result).containsExactly(ArticleSource.CHOSUN, ArticleSource.NAVER);
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.article.dto.ArticleDto;
 import com.codeit.monew.domain.article.entity.Article;
-import com.codeit.monew.domain.article.entity.ArticleSource;
+import com.codeit.monew.domain.article.ArticleSource;
 import com.codeit.monew.domain.article.mapper.ArticleMapper;
 import com.codeit.monew.domain.article.repository.ArticleRepository;
 import com.codeit.monew.domain.article.repository.ArticleViewHistoryRepository;
@@ -20,6 +20,7 @@ import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -54,8 +55,7 @@ class ArticleServiceTest {
 
   private Article createArticle(UUID articleId, ArticleSource source, String sourceUrl,
       String title, Instant publishDate, String summary) {
-    Article article = new Article(sourceUrl, source, title, publishDate, summary);
-
+    Article article = Article.createArticle(source, sourceUrl, title, publishDate, summary);
     if (articleId == null) {
       ReflectionTestUtils.setField(article, "id", UUID.randomUUID());
     } else {
@@ -171,4 +171,28 @@ class ArticleServiceTest {
       verify(articleMapper, never()).toDto(any(Article.class), anyLong(), anyLong(), anyBoolean());
     }
   }
+
+  @Nested
+  @DisplayName("뉴스 기사 출처 목록 조회 테스트")
+  class getSource {
+
+    @Test
+    @DisplayName("DB에 저장된 뉴스 기사의 출처 목록을 조회할 수 있다.")
+    void success_get_article_source() {
+      // given(준비)
+      List<ArticleSource> expectedSources = List.of(ArticleSource.CHOSUN, ArticleSource.NAVER,
+          ArticleSource.YEONHAP);
+
+      given(articleService.getSources()).willReturn(expectedSources);
+
+      // when(실행)
+      List<ArticleSource> result = articleService.getSources();
+
+      // then(검증)
+      assertEquals(expectedSources, result);
+
+      verify(articleRepository).findDistinctSource();
+    }
+  }
+
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,26 @@
+# 테스트 전용 설정입니다.
+spring:
+  sql:
+    init:
+      mode: never
+  # 각 테스트는 독립적인 H2 메모리 DB를 사용해 언제 실행해도 같은 결과가 나오도록 합니다.
+  datasource:
+    url: jdbc:h2:mem:test-practice-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # 테스트가 시작될 때 테이블을 만들고, 끝나면 정리하도록 설정해 테스트 간 간섭을 막습니다.
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    com.codeit.monew: debug # 애플리케이션 패키지에서 발생하는 로그
+    root: info # 전체 로그 레벨 설정


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #52 

## 📝작업 내용

- 뉴스 기사 출처 목록 조회 기능 구현
  - Controller, Service, Repository 로직 구현
- 요청 파라미터 형식 예외/필수 헤더 누락 예외 처리 추가
- 4xx와 5xx 예외의 로그 레벨 기준 분리
    - 예상치 못한 예외 및 서버 예외는 `error`
    - 의도한 예외는 `warn`

## 📸스크린샷 (선택)

- 해당사항 없음

## 💬리뷰 요구사항(선택)

- 해당사항 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기사 출처 조회용 API 엔드포인트 추가 (출처 목록 반환)
* **버그 수정 / 개선**
  * 전역 예외 처리 개선으로 오류 응답 및 로깅 정교화
  * 기존 기사 조회 API에 잘못된 요청(400) 응답 문서화 추가
* **문서화**
  * API 문서에 새로운 출처 엔드포인트 응답 스키마 추가
* **테스트**
  * 신규 엔드포인트 및 저장소 로직에 대한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->