### PR TITLE
[feat] 관심사 수정/삭제/구독/구독 취소에 대한 Service 및 Controller 구현

### DIFF
--- a/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
@@ -49,48 +49,4 @@ public class InterestController {
     return ResponseEntity.ok(response);
   }
 
-  // 3. 관심사 삭제
-  @DeleteMapping("/{interestId}")
-  public ResponseEntity<Void> delete(
-      @PathVariable UUID interestId
-  ) {
-    interestService.delete(interestId);
-    return ResponseEntity.noContent().build();
-  }
-
-  // 4. 관심사 목록 조회
-  @GetMapping
-  public ResponseEntity<CursorPageResponseInterestDto> getList(
-      @RequestParam(required = false) String keyword,
-      @RequestParam String orderBy,
-      @RequestParam String direction,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) LocalDateTime after,
-      @RequestParam int limit,
-      @RequestHeader("Monew-Request-User-ID") UUID userId
-  ) {
-    CursorPageResponseInterestDto response = interestService.getList(keyword, orderBy, direction, cursor, after, limit, userId);
-    return ResponseEntity.ok(response);
-  }
-
-  // 5. 관심사 구독
-  @PostMapping("/{interestId}/subscriptions")
-  public ResponseEntity<SubscriptionDto> subscribe(
-      @PathVariable UUID interestId,
-      @RequestHeader("Monew-Request-User-ID") UUID userId
-  ) {
-    SubscriptionDto response = interestService.subscribe(interestId, userId);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
-  }
-
-  // 6. 관심사 구독 취소
-  @DeleteMapping("/{interestId}/subscriptions")
-  public ResponseEntity<Void> unsubscribe(
-      @PathVariable UUID interestId,
-      @RequestHeader("Monew-Request-User-ID") UUID userId
-  ) {
-    interestService.unsubscribe(interestId, userId);
-    return ResponseEntity.noContent().build();
-  }
-
 }

--- a/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
@@ -1,15 +1,26 @@
 package com.codeit.monew.domain.interest.controller;
 
 import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
+import com.codeit.monew.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.monew.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.monew.domain.interest.dto.response.InterestDto;
+import com.codeit.monew.domain.interest.dto.response.SubscriptionDto;
 import com.codeit.monew.domain.interest.service.InterestService;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,6 +37,60 @@ public class InterestController {
   ) {
     InterestDto response = interestService.register(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 2. 관심사 수정
+  @PatchMapping("/{interestId}")
+  public ResponseEntity<InterestDto> update(
+      @PathVariable UUID interestId,
+      @RequestBody @Valid InterestUpdateRequest request
+  ) {
+    InterestDto response = interestService.update(interestId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  // 3. 관심사 삭제
+  @DeleteMapping("/{interestId}")
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID interestId
+  ) {
+    interestService.delete(interestId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 4. 관심사 목록 조회
+  @GetMapping
+  public ResponseEntity<CursorPageResponseInterestDto> getList(
+      @RequestParam(required = false) String keyword,
+      @RequestParam String orderBy,
+      @RequestParam String direction,
+      @RequestParam(required = false) String cursor,
+      @RequestParam(required = false) LocalDateTime after,
+      @RequestParam int limit,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    CursorPageResponseInterestDto response = interestService.getList(keyword, orderBy, direction, cursor, after, limit, userId);
+    return ResponseEntity.ok(response);
+  }
+
+  // 5. 관심사 구독
+  @PostMapping("/{interestId}/subscriptions")
+  public ResponseEntity<SubscriptionDto> subscribe(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    SubscriptionDto response = interestService.subscribe(interestId, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 6. 관심사 구독 취소
+  @DeleteMapping("/{interestId}/subscriptions")
+  public ResponseEntity<Void> unsubscribe(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    interestService.unsubscribe(interestId, userId);
+    return ResponseEntity.noContent().build();
   }
 
 }

--- a/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
@@ -49,4 +49,35 @@ public class InterestController {
     return ResponseEntity.ok(response);
   }
 
+  // 3. 관심사 삭제
+  @DeleteMapping("/{interestId}")
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID interestId
+  ) {
+    interestService.delete(interestId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 4. 관심사 목록 조회
+
+  // 5. 관심사 구독
+  @PostMapping("/{interestId}/subscriptions")
+  public ResponseEntity<SubscriptionDto> subscribe(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    SubscriptionDto response = interestService.subscribe(interestId, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 6. 관심사 구독 취소
+  @DeleteMapping("/{interestId}/subscriptions")
+  public ResponseEntity<Void> unsubscribe(
+      @PathVariable UUID interestId,
+      @RequestHeader("Monew-Request-User-ID") UUID userId
+  ) {
+    interestService.unsubscribe(interestId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
 }

--- a/src/main/java/com/codeit/monew/domain/interest/entity/Interest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/entity/Interest.java
@@ -1,5 +1,6 @@
 package com.codeit.monew.domain.interest.entity;
 
+import com.codeit.monew.global.common.base.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,12 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "interests")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Interest {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  @Column(columnDefinition = "uuid")
-  private UUID id;
+public class Interest extends BaseEntity {
 
   @Column(nullable = false, unique = true, length = 50)
   private String name;
@@ -34,17 +30,8 @@ public class Interest {
   @Column(nullable = false)
   private long subscriberCount = 0;
 
-  @Column(nullable = false, updatable = false)
-  private LocalDateTime createdAt;
-
   @OneToMany(mappedBy = "interest", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Keyword> keywords = new ArrayList<>();
-
-  // 엔티티가 DB에 저장되는 시점에 자동으로 생성 시각 세팅
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-  }
 
   // 관심사 생성
   public static Interest create(String name) {

--- a/src/main/java/com/codeit/monew/domain/interest/entity/Keyword.java
+++ b/src/main/java/com/codeit/monew/domain/interest/entity/Keyword.java
@@ -1,5 +1,6 @@
 package com.codeit.monew.domain.interest.entity;
 
+import com.codeit.monew.global.common.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -22,12 +23,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = @UniqueConstraint(columnNames = {"interest_id", "name"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Keyword {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  @Column(columnDefinition = "uuid")
-  private UUID id;
+public class Keyword extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "interest_id", nullable = false)
@@ -35,15 +31,6 @@ public class Keyword {
 
   @Column(nullable = false, length = 20)
   private String name;
-
-  @Column(nullable = false, updatable = false)
-  private LocalDateTime createdAt;
-
-  // 엔티티가 DB에 저장되는 시점에 자동으로 생성 시각 세팅
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-  }
 
   public static Keyword create(Interest interest, String name) {
     Keyword keyword = new Keyword();

--- a/src/main/java/com/codeit/monew/domain/interest/entity/Subscription.java
+++ b/src/main/java/com/codeit/monew/domain/interest/entity/Subscription.java
@@ -1,6 +1,7 @@
 package com.codeit.monew.domain.interest.entity;
 
 import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.global.common.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -23,12 +24,7 @@ import lombok.NoArgsConstructor;
     uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "interest_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Subscription {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  @Column(columnDefinition = "uuid")
-  private UUID id;
+public class Subscription extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
@@ -37,15 +33,6 @@ public class Subscription {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "interest_id", nullable = false)
   private Interest interest;
-
-  @Column(nullable = false, updatable = false)
-  private LocalDateTime createdAt;
-
-  // 엔티티가 DB에 저장되는 시점에 자동으로 생성 시각 세팅
-  @PrePersist
-  protected void onCreate() {
-    this.createdAt = LocalDateTime.now();
-  }
 
   public static Subscription create(User user, Interest interest) {
     Subscription subscription = new Subscription();

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InterestRepository extends JpaRepository<Interest, UUID> {
 
@@ -14,4 +16,13 @@ public interface InterestRepository extends JpaRepository<Interest, UUID> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT i.name FROM Interest i")
   List<String> findAllNamesWithLock();
+
+  // 구독자 수 atomic 업데이트
+  @Modifying
+  @Query("UPDATE Interest i SET i.subscriberCount = i.subscriberCount + 1 WHERE i.id = :interestId")
+  void incrementSubscriberCount(@Param("interestId") UUID interestId);
+
+  @Modifying
+  @Query("UPDATE Interest i SET i.subscriberCount = i.subscriberCount - 1 WHERE i.id = :id AND i.subscriberCount > 0")
+  void decrementSubscriberCount(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
@@ -18,11 +18,11 @@ public interface InterestRepository extends JpaRepository<Interest, UUID> {
   List<String> findAllNamesWithLock();
 
   // 구독자 수 atomic 업데이트
-  @Modifying
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("UPDATE Interest i SET i.subscriberCount = i.subscriberCount + 1 WHERE i.id = :interestId")
-  void incrementSubscriberCount(@Param("interestId") UUID interestId);
+  int incrementSubscriberCount(@Param("interestId") UUID interestId);
 
-  @Modifying
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("UPDATE Interest i SET i.subscriberCount = i.subscriberCount - 1 WHERE i.id = :id AND i.subscriberCount > 0")
-  void decrementSubscriberCount(@Param("id") UUID id);
+  int decrementSubscriberCount(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
@@ -1,8 +1,11 @@
 package com.codeit.monew.domain.interest.repository;
 
 import com.codeit.monew.domain.interest.entity.Subscription;
+import jakarta.transaction.Transactional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
@@ -10,6 +13,9 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
   boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
 
   // 구독 취소용
-  void deleteByUserIdAndInterestId(UUID userId, UUID interestId);
+  @Transactional
+  @Modifying
+  @Query("DELETE FROM Subscription s WHERE s.user.id = :userId AND s.interest.id = :interestId")
+  long deleteByUserIdAndInterestId(UUID userId, UUID interestId);
 
 }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
@@ -6,11 +6,13 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
   // 중복 구독 확인용
-  boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+  boolean existsByUserIdAndInterestId(@Param("userId") UUID userId,
+      @Param("interestId") UUID interestId);
 
   // 구독 취소용
   @Transactional

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -138,13 +138,11 @@ public class InterestService {
     Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
 
-    // 구독 여부 확인
-    if (!subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
+    // 구독 여부 확인 및 구독 취소
+    long deleted = subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
+    if (deleted == 0) {
       throw new IllegalArgumentException("구독 중이지 않은 관심사입니다.");
     }
-
-    // 구독 취소
-    subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
 
     // 구독자 수 감소
     interest.decreaseSubscriberCount();

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -13,6 +13,7 @@ import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import java.util.UUID;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -111,21 +112,21 @@ public class InterestService {
     Interest interest = interestRepository.findById(interestId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
 
-    // 중복 구독 확인
-    if (subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
-      throw new IllegalArgumentException("이미 구독 중인 관심사입니다.");
-    }
-
     // 사용자 존재 여부 확인
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-    // 구독 저장
-    Subscription subscription = Subscription.create(user, interest);
-    subscriptionRepository.save(subscription);
+    // 구독 저장 (DB UNIQUE 제약으로 중복 방지)
+    Subscription subscription;
+    try {
+      subscription = Subscription.create(user, interest);
+      subscriptionRepository.save(subscription);
+    } catch (DataIntegrityViolationException e) {
+      throw new IllegalArgumentException("이미 구독 중인 관심사입니다.");
+    }
 
     // 구독자 수 증가
-    interest.increaseSubscriberCount();
+    interestRepository.incrementSubscriberCount(interestId);
 
     return SubscriptionDto.from(subscription);
   }
@@ -145,6 +146,6 @@ public class InterestService {
     }
 
     // 구독자 수 감소
-    interest.decreaseSubscriberCount();
+    interestRepository.decrementSubscriberCount(interestId);
   }
 }

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -82,4 +82,19 @@ public class InterestService {
 
     return InterestDto.from(interest);
   }
+
+  // 3. 관심사 삭제
+  @Transactional
+  public void delete(UUID interestId) {
+      // 관심사 존재 여부 확인
+      Interest interest = interestRepository.findById(interestId)
+          .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
+
+      // 물리 삭제 (CASCADE로 keyword, subscription 자동 삭제)
+      interestRepository.delete(interest);
+  }
+
+  // 4. 관심사 목록 조회
+  // 5. 관심사 구독
+  // 6. 관심사 구독 취소
 }

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -51,7 +51,7 @@ public class InterestService {
     List<Keyword> keywords = request.keywords().stream()
         .map(name -> Keyword.create(interest, name))
         .toList();
-
+    keywordRepository.saveAll(keywords);
     interest.getKeywords().addAll(keywords);
 
     return InterestDto.from(interest);

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -3,10 +3,15 @@ package com.codeit.monew.domain.interest.service;
 import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.monew.domain.interest.dto.request.InterestUpdateRequest;
 import com.codeit.monew.domain.interest.dto.response.InterestDto;
+import com.codeit.monew.domain.interest.dto.response.SubscriptionDto;
 import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.entity.Keyword;
+import com.codeit.monew.domain.interest.entity.Subscription;
 import com.codeit.monew.domain.interest.repository.InterestRepository;
 import com.codeit.monew.domain.interest.repository.KeywordRepository;
+import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
 import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
@@ -21,6 +26,8 @@ public class InterestService {
 
   private final InterestRepository interestRepository;
   private final KeywordRepository keywordRepository;
+  private final SubscriptionRepository subscriptionRepository;
+  private final UserRepository userRepository;
 
   // 1. 관심사 등록
   @Transactional
@@ -95,6 +102,51 @@ public class InterestService {
   }
 
   // 4. 관심사 목록 조회
+
   // 5. 관심사 구독
+  @Transactional
+  public SubscriptionDto subscribe(UUID interestId, UUID userId) {
+
+    // 관심사 존재 여부 확인
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
+
+    // 중복 구독 확인
+    if (subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
+      throw new IllegalArgumentException("이미 구독 중인 관심사입니다.");
+    }
+
+    // 사용자 존재 여부 확인
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    // 구독 저장
+    Subscription subscription = Subscription.create(user, interest);
+    subscriptionRepository.save(subscription);
+
+    // 구독자 수 증가
+    interest.increaseSubscriberCount();
+
+    return SubscriptionDto.from(subscription);
+  }
+
   // 6. 관심사 구독 취소
+  @Transactional
+  public void unsubscribe(UUID interestId, UUID userId) {
+
+    // 관심사 존재 여부 확인
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
+
+    // 구독 여부 확인
+    if (!subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)) {
+      throw new IllegalArgumentException("구독 중이지 않은 관심사입니다.");
+    }
+
+    // 구독 취소
+    subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
+
+    // 구독자 수 감소
+    interest.decreaseSubscriberCount();
+  }
 }

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -1,11 +1,13 @@
 package com.codeit.monew.domain.interest.service;
 
 import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
+import com.codeit.monew.domain.interest.dto.request.InterestUpdateRequest;
 import com.codeit.monew.domain.interest.dto.response.InterestDto;
 import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.entity.Keyword;
 import com.codeit.monew.domain.interest.repository.InterestRepository;
 import com.codeit.monew.domain.interest.repository.KeywordRepository;
+import java.util.UUID;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class InterestService {
   private final InterestRepository interestRepository;
   private final KeywordRepository keywordRepository;
 
+  // 1. 관심사 등록
   @Transactional
   public InterestDto register(InterestRegisterRequest request) {
 
@@ -54,5 +57,29 @@ public class InterestService {
     int maxLen = Math.max(a.length(), b.length());
     if (maxLen == 0) return 1.0;
     return 1.0 - ((double) distance / maxLen);
+  }
+
+  // 2. 관심사 수정
+  @Transactional
+  public InterestDto update(UUID interestId, InterestUpdateRequest request) {
+
+    // 관심사 존재 여부 확인
+    Interest interest = interestRepository.findById(interestId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관심사입니다: " + interestId));
+
+    // 기존 키워드 전체 삭제
+    keywordRepository.deleteAllByInterestId(interestId);
+
+    // 새 키워드 저장
+    List<Keyword> keywords = request.keywords().stream()
+        .map(name -> Keyword.create(interest, name))
+        .toList();
+    keywordRepository.saveAll(keywords);
+
+    // interest 키워드 리스트 갱신
+    interest.getKeywords().clear();
+    interest.getKeywords().addAll(keywords);
+
+    return InterestDto.from(interest);
   }
 }

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -56,7 +56,6 @@ public class InterestService {
 
     return InterestDto.from(interest);
   }
-
   private double calculateSimilarity(String a, String b) {
     a = a.toLowerCase();
     b = b.toLowerCase();


### PR DESCRIPTION
## #️⃣연관된 이슈

#11 #13 #14 #34 #38 

## 📝작업 내용
- 관심사 수정 Service 구현
- 관심사 삭제 Service 구현
- 관심사 구독 및 구독 취소 Service 구현
- 관심사 Controller 구현(수정/삭제/구독/구독 취소)

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- GlobalExceptionHandler에 따른 예외 처리 변경 사항은 이후 pr에 반영하겠습니다.
- service 관련 커밋 내역을 깔끔하게 하려다 controller 구현 내용을 실수로 추가했다 삭제했습니다. 무시하시면 될 것 같습니다...🥲
- 이후 등록/수정/삭제에 대한 테스트 코드를 작성할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관심사 업데이트·삭제 API와 구독/구독 취소 API가 추가되었습니다.
* **개선**
  * 구독 등록/취소 시 중복 처리 및 오류 대응이 강화되었습니다.
  * 구독자 수 증감이 데이터베이스 수준에서 원자적으로 처리되어 일관성이 향상되었습니다.
  * 관심사 등록 시 연관 키워드가 영구 저장되도록 개선되었습니다.
* **리팩터**
  * 엔티티 공통 필드가 공통 상속 구조로 통합되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->