### PR TITLE
[feat] 사용자 수정 로직 구현

### DIFF
--- a/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
@@ -2,20 +2,26 @@ package com.codeit.monew.domain.user.controller;
 
 import com.codeit.monew.domain.user.dto.UserDto;
 import com.codeit.monew.domain.user.dto.UserRegisterRequest;
+import com.codeit.monew.domain.user.dto.UserUpdateRequest;
 import com.codeit.monew.domain.user.service.UserService;
 import com.codeit.monew.global.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,5 +46,23 @@ public class UserController {
   ) {
     UserDto dto = userService.register(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+  }
+
+  @PatchMapping("/{userId}")
+  @Operation(summary = "사용자 정보 수정", description = "사용자의 닉네임을 수정합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공", content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "403", description = "사용자 정보 수정 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<UserDto> update(
+      @Parameter(description = "사용자 ID")@PathVariable UUID userId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId,
+      @Valid @RequestBody UserUpdateRequest request
+  ) {
+    UserDto dto = userService.update(userId, requestUserId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(dto);
   }
 }

--- a/src/main/java/com/codeit/monew/domain/user/service/UserService.java
+++ b/src/main/java/com/codeit/monew/domain/user/service/UserService.java
@@ -2,12 +2,18 @@ package com.codeit.monew.domain.user.service;
 
 import com.codeit.monew.domain.user.dto.UserDto;
 import com.codeit.monew.domain.user.dto.UserRegisterRequest;
+import com.codeit.monew.domain.user.dto.UserUpdateRequest;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.mapper.UserMapper;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.exception.MonewException;
 import com.codeit.monew.global.exception.user.DuplicateEmailException;
+import com.codeit.monew.global.exception.user.UserAccessDeniedException;
+import com.codeit.monew.global.exception.user.UserNotFoundException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +39,24 @@ public class UserService {
 
     log.info("[USER_CREATE] 유저 생성 완료: userId={}", user.getId());
 
+    return userMapper.toDto(user);
+  }
+
+  public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
+    log.debug("[USER_UPDATE] 유저 수정 요청: userId={}", userId);
+
+    // URI에 포함된 userId와 헤더에 포함된 requestUserId를 비교해서 다르다면 예외를 던진다.
+    if (!userId.equals(requestUserId)) {
+      throw new UserAccessDeniedException(requestUserId);
+    }
+
+    // Soft Delete를 고려해 findByIdAndDeletedAtIsNull()을 호출
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+
+    user.updateNickname(request.nickname());
+
+    log.info("[USER_UPDATE] 유저 수정 완료: userId={}", user.getId());
     return userMapper.toDto(user);
   }
 

--- a/src/main/java/com/codeit/monew/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/monew/global/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
   // User 관련 에러 코드
   USER_NOT_FOUND("유저를 찾을 수 없습니다."),
   DUPLICATE_EMAIL("이미 사용중인 이메일입니다."),
+  USER_ACCESS_DENIED("사용자 수정, 삭제 권한이 없습니다."),
 
   // Article 관련 에러 코드
   ARTICLE_NOT_FOUND("뉴스 기사 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -132,7 +131,7 @@ public class GlobalExceptionHandler {
 
       case USER_NOT_FOUND, ARTICLE_NOT_FOUND -> HttpStatus.NOT_FOUND;
       case DUPLICATE_EMAIL -> HttpStatus.CONFLICT;
-      case COMMENT_UPDATE_FORBIDDEN -> HttpStatus.FORBIDDEN;
+      case USER_ACCESS_DENIED, COMMENT_UPDATE_FORBIDDEN -> HttpStatus.FORBIDDEN;
       case COMMENT_CONTENT_BLANK, COMMENT_CONTENT_TOO_LONG -> HttpStatus.BAD_REQUEST;
 
       default -> HttpStatus.INTERNAL_SERVER_ERROR; // 지금은 디버깅 에러 잡는 용도, 나중에 지워야 함

--- a/src/main/java/com/codeit/monew/global/exception/user/UserAccessDeniedException.java
+++ b/src/main/java/com/codeit/monew/global/exception/user/UserAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.codeit.monew.global.exception.user;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import java.util.UUID;
+
+public class UserAccessDeniedException extends UserException {
+
+  public UserAccessDeniedException(UUID requesterId) {
+    super(ErrorCode.USER_ACCESS_DENIED, "requesterId", requesterId);
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
@@ -8,10 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.codeit.monew.domain.user.dto.UserDto;
 import com.codeit.monew.domain.user.dto.UserRegisterRequest;
+import com.codeit.monew.domain.user.dto.UserUpdateRequest;
 import com.codeit.monew.domain.user.service.UserService;
 import com.codeit.monew.global.exception.ErrorCode;
 import com.codeit.monew.global.exception.GlobalExceptionHandler;
 import com.codeit.monew.global.exception.user.DuplicateEmailException;
+import com.codeit.monew.global.exception.user.UserAccessDeniedException;
+import com.codeit.monew.global.exception.user.UserNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.UUID;
@@ -44,11 +47,10 @@ class UserControllerTest {
 
     @Test
     @DisplayName("유효한 회원가입 요청 시 201 상태코드와 등록된 사용자 정보가 반환된다.")
-    void success_register_user() throws Exception {
+    void should_register_user_success_and_return_201() throws Exception {
       // given
-
       UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname",
-          "Password123!");
+          "testPassword1!");
       UUID userId = UUID.randomUUID();
       Instant createdAt = Instant.now();
       UserDto responseDto = new UserDto(userId, "test@email.com", "testNickname", createdAt);
@@ -66,10 +68,10 @@ class UserControllerTest {
 
     @Test
     @DisplayName("중복된 이메일로 회원가입 요청 시 409 상태 코드와 DuplicateEmail 예외가 발생한다.")
-    void fail_register_when_email_duplicated() throws Exception {
+    void should_fail_register_when_email_duplicated() throws Exception {
       // given
       UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname",
-          "Password123!");
+          "testPassword1!");
 
       given(userService.register(any(UserRegisterRequest.class))).willThrow(
           new DuplicateEmailException(request.email()));
@@ -87,15 +89,96 @@ class UserControllerTest {
 
     @Test
     @DisplayName("잘못된 이메일 형식으로 회원가입 요청 시 400 상태 코드가 반환된다.")
-    void fail_register_when_email_invalid() throws Exception {
+    void should_fail_register_when_email_invalid() throws Exception {
       // given
-      UserRegisterRequest request = new UserRegisterRequest("invalid-email", "testNickname", "Password123!");
+      UserRegisterRequest request = new UserRegisterRequest("invalid-email", "testNickname",
+          "testPassword1!");
       // when, then
       mockMvc.perform(post("/api/users")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.status").value(400));
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 수정 API 테스트")
+  class updateUser {
+
+    @Test
+    @DisplayName("유효한 요청 시 200 상태코드와 수정된 사용자 정보가 반환된다.")
+    void should_update_user_success_and_return_200() throws Exception {
+      // given
+      UserUpdateRequest request = new UserUpdateRequest("newNickName");
+      UUID userId = UUID.randomUUID();
+      Instant createdAt = Instant.now();
+      UserDto responseDto = new UserDto(userId, "test@email.com", "newNickName", createdAt);
+
+      given(userService.update(any(UUID.class), any(UUID.class), any(UserUpdateRequest.class))).willReturn(responseDto);
+      // when, then
+      mockMvc.perform(patch("/api/users/" + userId)
+              .header("Monew-Request-User-ID", userId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(userId.toString()))
+          .andExpect(jsonPath("$.nickname").value(request.nickname()));
+    }
+
+    @Test
+    @DisplayName("잘못된 형식으로 수정 요청 시 400 상태 코드가 반환된다.")
+    void should_fail_update_user_when_nickname_invalid() throws Exception {
+      // given
+      UserUpdateRequest request = new UserUpdateRequest("");
+      UUID userId = UUID.randomUUID();
+
+      // when, then
+      mockMvc.perform(patch("/api/users/" + userId)
+              .header("Monew-Request-User-ID", userId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 수정할 사용자의 ID가 다르면 403 상태 코드가 반환된다.")
+    void should_fail_update_user_when_id_mismatch() throws Exception {
+      // given
+      UserUpdateRequest request = new UserUpdateRequest("newNickName");
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+
+      given(userService.update(any(UUID.class), any(UUID.class), any(UserUpdateRequest.class))).willThrow(
+          new UserAccessDeniedException(userId)
+      );
+      // when, then
+      mockMvc.perform(patch("/api/users/" + userId)
+              .header("Monew-Request-User-ID", requestUserId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("수정할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
+    void should_update_user_fail_when_id_mismatch() throws Exception {
+      // given
+      UserUpdateRequest request = new UserUpdateRequest("newNickName");
+      UUID userId = UUID.randomUUID();
+
+      given(userService.update(any(UUID.class), any(UUID.class), any(UserUpdateRequest.class))).willThrow(
+          new UserNotFoundException(userId)
+      );
+      // when, then
+      mockMvc.perform(patch("/api/users/" + userId)
+              .header("Monew-Request-User-ID", userId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value(404));
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
@@ -151,7 +151,7 @@ class UserControllerTest {
       UUID requestUserId = UUID.randomUUID();
 
       given(userService.update(any(UUID.class), any(UUID.class), any(UserUpdateRequest.class))).willThrow(
-          new UserAccessDeniedException(userId)
+          new UserAccessDeniedException(requestUserId)
       );
       // when, then
       mockMvc.perform(patch("/api/users/" + userId)
@@ -164,7 +164,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("수정할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
-    void should_update_user_fail_when_id_mismatch() throws Exception {
+    void should_fail_update_user_fail_when_user_not_found() throws Exception {
       // given
       UserUpdateRequest request = new UserUpdateRequest("newNickName");
       UUID userId = UUID.randomUUID();

--- a/src/test/java/com/codeit/monew/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/service/UserServiceTest.java
@@ -8,12 +8,16 @@ import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.user.dto.UserDto;
 import com.codeit.monew.domain.user.dto.UserRegisterRequest;
+import com.codeit.monew.domain.user.dto.UserUpdateRequest;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.mapper.UserMapper;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.ErrorCode;
 import com.codeit.monew.global.exception.user.DuplicateEmailException;
+import com.codeit.monew.global.exception.user.UserAccessDeniedException;
+import com.codeit.monew.global.exception.user.UserNotFoundException;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -56,11 +60,13 @@ class UserServiceTest {
     @DisplayName("사용자 회원가입에 성공해야 한다.")
     void should_register_user_success() {
       // given
-      UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname", "testPassword1!");
+      UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname",
+          "testPassword1!");
       UUID userId = UUID.randomUUID();
       Instant createdAt = Instant.now();
       User user = createUser(userId, request.email(), request.nickname(), request.password());
-      UserDto expectedUserDto = new UserDto(user.getId(), user.getEmail(), user.getNickname(), createdAt);
+      UserDto expectedUserDto = new UserDto(user.getId(), user.getEmail(), user.getNickname(),
+          createdAt);
 
       given(userRepository.existsByEmail(request.email())).willReturn(false);
       given(userMapper.toDto(any(User.class))).willReturn(expectedUserDto);
@@ -81,7 +87,8 @@ class UserServiceTest {
     @DisplayName("이미 존재하는 이메일로 회원가입을 요청하면 DuplicateEmail 예외가 발생한다.")
     void should_fail_register_when_email_duplicated() {
       // given
-      UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname", "Password123!");
+      UserRegisterRequest request = new UserRegisterRequest("test@email.com", "testNickname",
+          "testPassword1!");
 
       given(userRepository.existsByEmail(request.email())).willReturn(true);
 
@@ -91,6 +98,65 @@ class UserServiceTest {
       assertEquals(ErrorCode.DUPLICATE_EMAIL, exception.getErrorCode());
       verify(userRepository).existsByEmail(request.email());
       verify(userRepository, never()).save(any(User.class));
+      verify(userMapper, never()).toDto(any(User.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 수정 테스트")
+  class updateUser {
+
+    @Test
+    @DisplayName("사용자 닉네임 수정에 성공해야 한다.")
+    void should_update_user_nickname_success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      Instant createdAt = Instant.now();
+      User user = createUser(userId, "test@email.com", "testNickname",
+          "testPassword1!");
+      UserUpdateRequest request = new UserUpdateRequest("newNickname");
+      UserDto expectedUserDto = new UserDto(user.getId(), user.getEmail(), request.nickname(),
+          createdAt);
+
+      given(userRepository.findByIdAndDeletedAtIsNull(any(UUID.class))).willReturn(Optional.of(user));
+      given(userMapper.toDto(any(User.class))).willReturn(expectedUserDto);
+
+      // when
+      UserDto result = userService.update(userId, userId, request);
+
+      // then
+      assertEquals(expectedUserDto.nickname(), result.nickname());
+      verify(userMapper).toDto(any(User.class));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 UserNotFound 예외가 발생한다.")
+    void should_fail_update_user_nickname_when_user_not_found() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UserUpdateRequest request = new UserUpdateRequest("newNickname");
+
+      given(userRepository.findByIdAndDeletedAtIsNull(any(UUID.class))).willReturn(Optional.empty());
+
+      // when, then
+      UserNotFoundException exception = assertThrows(UserNotFoundException.class,
+          () -> userService.update(userId, userId, request));
+      assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+      verify(userMapper, never()).toDto(any(User.class));
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 수정할 사용자의 ID가 다르면 UserAccessDenied 예외가 발생한다.")
+    void should_fail_update_user_nickname_when_id_mismatch() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+      UserUpdateRequest request = new UserUpdateRequest("newNickname");
+
+      // when, then
+      UserAccessDeniedException exception = assertThrows(UserAccessDeniedException.class,
+          () -> userService.update(userId, requestUserId, request));
+      assertEquals(ErrorCode.USER_ACCESS_DENIED, exception.getErrorCode());
       verify(userMapper, never()).toDto(any(User.class));
     }
   }


### PR DESCRIPTION
## #️⃣연관된 이슈
Closes #22 

## 📝작업 내용

- 사용자 수정 Service, Controller 로직을 작성하고 성공/실패 테스트 케이스를 작성했습니다.

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)
Swagger 문서에서 사용자 관련 API는 "Monew-Request-User-ID"를 파라미터로 받고있지 않은데, 403 권한에 대한 응답 예시는 나와있습니다.
권한 로직을 작성하려면 Monew-Request-User-ID 헤더가 필요하기에 컨트롤러에 추가하여 작성하였는데 괜찮을지 의견을 묻고싶습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 수정용 PATCH 엔드포인트 추가 — 닉네임 변경 및 요청자 식별 헤더 기반 검증 지원

* **버그 수정**
  * 권한 관련 예외의 HTTP 상태 매핑 개선(권한없음 시 403 반환)
  * 접근권한 검증 강화 및 관련 오류 코드 추가

* **테스트**
  * 사용자 업데이트 성공·실패(권한없음·미존재) 시나리오에 대한 단위·통합 테스트 추가 및 기존 테스트 명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->