### PR TITLE
[feat] 댓글 논리/물리 삭제 로직 구현

### DIFF
--- a/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
@@ -35,7 +35,7 @@ public class CommentController {
   @Operation(summary = "댓글 등록", description = "새로운 댓글을 등록합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "201", description = "등록 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
+      @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   @PostMapping

--- a/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,5 +76,35 @@ public class CommentController {
     log.info("댓글 수정 성공: 수정된 commentId= {}", response.id());
 
     return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "댓글 논리 삭제", description = "댓글을 논리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "댓글 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{commentId}")
+  public ResponseEntity<Void> deleteComment(@PathVariable UUID commentId) {
+
+    log.debug("댓글 논리 삭제 요청: commentId={}", commentId);
+
+    commentService.deleteComment(commentId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "댓글 물리 삭제", description = "댓글을 물리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "댓글 정보 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{commentId}/hard")
+  public ResponseEntity<Void> hardDeleteComment(@PathVariable UUID commentId) {
+
+    log.debug("댓글 물리 삭제 요청: commentId={}", commentId);
+
+    commentService.hardDeleteComment(commentId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
@@ -36,7 +36,7 @@ public class CommentController {
   @Operation(summary = "댓글 등록", description = "새로운 댓글을 등록합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "201", description = "등록 성공"),
-      @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })
   @PostMapping
@@ -59,7 +59,8 @@ public class CommentController {
   @Operation(summary = "댓글 정보 수정", description = "댓글의 내용을 수정합니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "수정 성공"),
-      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패 / 권한 없음)"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)"),
+      @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
       @ApiResponse(responseCode = "404", description = "댓글 정보 없음"),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류")
   })

--- a/src/main/java/com/codeit/monew/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/monew/domain/comment/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.codeit.monew.domain.comment.entity.Comment;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,4 +14,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
   @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.id = :id AND c.deletedAt IS NULL")
   Optional<Comment> findByIdWithUser(@Param("id") UUID id);
+
+  // 댓글 물리 삭제 전용 쿼리
+  @Modifying
+  @Query("DELETE FROM Comment c WHERE c.id = :id")
+  void deleteByIdHard(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
@@ -66,4 +66,33 @@ public class CommentService {
     boolean likedByMe = false; // 좋아요 기능 구현 전까지 고정값, TODO: 좋아요 기능 구현 후 수정
     return commentMapper.toDto(comment, comment.getUser().getNickname(), likedByMe);
   }
+
+  // 댓글 논리 삭제 (삭제 기본값)
+  @Transactional
+  public void deleteComment(UUID commentId) {
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+    // 엔티티에 설정된 @SQLDelete 작동 -> deleted_at에 현재 시간 기록
+    commentRepository.delete(comment);
+    log.info("댓글 논리 삭제 완료: commentId= {}", commentId);
+  }
+
+  // 댓글 물리 삭제
+  @Transactional
+  public void hardDeleteComment(UUID commentId) {
+    // 1. 댓글 존재 여부 확인
+    boolean exists = commentRepository.existsById(commentId);
+    if (!exists) {
+      throw new CommentNotFoundException(commentId);
+    }
+
+    // 2. 연관 데이터 물리 삭제
+    // TODO: CommentLikeRepository 생성 후 적용 필요
+    // commentLikeRepository.deleteByCommentId(commentId);
+
+    // 3. 댓글 물리 삭제
+    commentRepository.deleteByIdHard(commentId);
+    log.info("댓글 물리 삭제 완료: commentId= {}", commentId);
+  }
 }

--- a/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
@@ -23,6 +23,9 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -100,7 +103,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("올바른 요청을 보내면 200 OK와 수정된 데이터를 반환한다.")
-    void success() throws Exception {
+    void success_update_comment() throws Exception {
       // given
       UUID commentId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
@@ -193,6 +196,81 @@ class CommentControllerTest {
           .andDo(print())
           .andExpect(status().isForbidden())
           .andExpect(jsonPath("$.code").value("COMMENT_UPDATE_FORBIDDEN"));
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 논리 삭제 API 테스트")
+  class DeleteCommentAPI {
+
+    private final String URL = "/api/comments/{commentId}";
+
+    @Test
+    @DisplayName("정상적인 삭제 요청 시 204 No Content를 반환한다.")
+    void success_logical_delete() throws Exception {
+      // given
+      UUID commentId = UUID.randomUUID();
+      // 삭제 메서드는 반환값이 void이므로 willDoNothing() 사용 (생략 가능)
+
+      // when & then
+      mockMvc.perform(delete(URL, commentId))
+          .andDo(print())
+          .andExpect(status().isNoContent()); // 💡 204 상태 코드 검증
+
+      verify(commentService).deleteComment(commentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID로 논리 삭제 요청 시 404 Not Found를 반환한다.")
+    void fail_logical_delete_notFound() throws Exception {
+      // given
+      UUID commentId = UUID.randomUUID();
+
+      doThrow(new CommentNotFoundException(commentId))
+          .when(commentService).deleteComment(commentId);
+
+      // when & then
+      mockMvc.perform(delete(URL, commentId))
+          .andDo(print())
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("COMMENT_NOT_FOUND"));
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 물리 삭제 API 테스트")
+  class HardDeleteCommentAPI {
+
+    private final String URL = "/api/comments/{commentId}/hard";
+
+    @Test
+    @DisplayName("정상적인 물리 삭제 요청 시 204 No Content를 반환한다.")
+    void success_hard_delete() throws Exception {
+      // given
+      UUID commentId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(delete(URL, commentId))
+          .andDo(print())
+          .andExpect(status().isNoContent());
+
+      verify(commentService).hardDeleteComment(commentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID로 물리 삭제 요청 시 404 Not Found를 반환한다.")
+    void fail_hard_delete_notFound() throws Exception {
+      // given
+      UUID commentId = UUID.randomUUID();
+
+      doThrow(new CommentNotFoundException(commentId))
+          .when(commentService).hardDeleteComment(commentId);
+
+      // when & then
+      mockMvc.perform(delete(URL, commentId))
+          .andDo(print())
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("COMMENT_NOT_FOUND"));
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
@@ -175,7 +175,7 @@ class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("작성자가 아닌 사람이 수정하면 400 Bad Request(권한 없음)를 반환한다.")
+    @DisplayName("작성자가 아닌 사람이 수정하면 403 Forbidden을 반환한다.")
     void fail_updateForbidden() throws Exception {
       // given
       UUID commentId = UUID.randomUUID(); // 작성자
@@ -191,7 +191,7 @@ class CommentControllerTest {
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andDo(print())
-          .andExpect(status().isBadRequest())
+          .andExpect(status().isForbidden())
           .andExpect(jsonPath("$.code").value("COMMENT_UPDATE_FORBIDDEN"));
     }
   }

--- a/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
@@ -193,4 +193,75 @@ class CommentServiceTest {
           .isInstanceOf(com.codeit.monew.global.exception.comment.CommentUpdateForbiddenException.class);
     }
   }
+
+  @Nested
+  @DisplayName("댓글 논리 삭제 (deleteComment) 테스트")
+  class DeleteComment {
+
+    @Test
+    @DisplayName("존재하는 댓글 ID로 요청하면 논리 삭제(commentRepository.delete)가 수행된다.")
+    void success_logical_delete() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      Comment mockComment = mock(Comment.class);
+
+      given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+      // when
+      commentService.deleteComment(commentId);
+
+      // then
+      // 일반 delete()가 호출되었는지 검증 -> 엔티티의 @SQLDelete가 작동하여 논리 삭제됨
+      verify(commentRepository).delete(mockComment);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 ID면 CommentNotFoundException이 발생한다.")
+    void fail_logical_delete_notFound() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> commentService.deleteComment(commentId))
+          .isInstanceOf(com.codeit.monew.global.exception.comment.CommentNotFoundException.class);
+
+      verify(commentRepository, never()).delete(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 물리 삭제 (hardDeleteComment) 테스트")
+  class HardDeleteComment {
+
+    @Test
+    @DisplayName("존재하는 댓글 ID로 요청하면 물리 삭제(commentRepository.deleteByIdHard)가 수행된다.")
+    void success_hard_delete() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      given(commentRepository.existsById(commentId)).willReturn(true);
+
+      // when
+      commentService.hardDeleteComment(commentId);
+
+      // then
+      // 일반 delete()가 아닌, deleteByIdHard()가 호출되었는지 검증
+      verify(commentRepository).deleteByIdHard(commentId);
+      verify(commentRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 댓글 ID면 CommentNotFoundException이 발생한다.")
+    void fail_hard_delete_notFound() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      given(commentRepository.existsById(commentId)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> commentService.hardDeleteComment(commentId))
+          .isInstanceOf(com.codeit.monew.global.exception.comment.CommentNotFoundException.class);
+
+      verify(commentRepository, never()).deleteByIdHard(any());
+    }
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #26

## 📝작업 내용

- 댓글 논리/물리 삭제 로직 구현
  - CommentRepository: 물리 삭제 전용 deleteByIdHard 쿼리 추가
  - CommentService: 논리 삭제(`deleteComment`) 및 물리 삭제(`hardDeleteComment`) 비즈니스 로직 구현
  - CommentController: DELETE /api/comments/{commentId} 및 /hard 엔드포인트 매핑
  - 댓글 논리/물리 삭제 테스트 케이스 작성

## 📸스크린샷 (선택)
- 해당사항 없음

## 💬리뷰 요구사항(선택)
- 해당사항 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글 삭제 기능 추가: 논리 삭제(soft) 및 물리 삭제(hard) 지원 및 관련 삭제 API 추가
* **Bug Fixes**
  * 댓글 수정 API의 오류 응답 문구 정비: 입력 검증 실패와 편집 권한 없음 응답 구분
* **Tests**
  * 삭제 동작 및 수정 권한 처리를 검증하는 테스트 추가 및 일부 테스트명 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->