### PR TITLE
[feat] 사용자 삭제 로직 구현

### DIFF
--- a/src/main/java/com/codeit/monew/MonewApplication.java
+++ b/src/main/java/com/codeit/monew/MonewApplication.java
@@ -4,9 +4,11 @@ import com.codeit.monew.global.config.AwsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(AwsProperties.class)
+@EnableScheduling
 public class MonewApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,11 +59,43 @@ public class UserController {
       @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   public ResponseEntity<UserDto> update(
-      @Parameter(description = "사용자 ID")@PathVariable UUID userId,
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId,
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId,
       @Valid @RequestBody UserUpdateRequest request
   ) {
     UserDto dto = userService.update(userId, requestUserId, request);
     return ResponseEntity.status(HttpStatus.OK).body(dto);
+  }
+
+  @DeleteMapping("/{userId}")
+  @Operation(summary = "사용자 논리 삭제", description = "사용자를 논리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<UserDto> softDelete(
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    userService.softDelete(userId, requestUserId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @DeleteMapping("/{userId}/hard")
+  @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "사용자 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<UserDto> hardDelete(
+      @Parameter(description = "사용자 ID") @PathVariable UUID userId,
+      @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
+  ) {
+    userService.hardDelete(userId, requestUserId);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/monew/domain/user/controller/UserController.java
@@ -70,12 +70,12 @@ public class UserController {
   @DeleteMapping("/{userId}")
   @Operation(summary = "사용자 논리 삭제", description = "사용자를 논리적으로 삭제합니다.")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content()),
       @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "사용자 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ResponseEntity<UserDto> softDelete(
+  public ResponseEntity<Void> softDelete(
       @Parameter(description = "사용자 ID") @PathVariable UUID userId,
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
   ) {
@@ -86,12 +86,12 @@ public class UserController {
   @DeleteMapping("/{userId}/hard")
   @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content(schema = @Schema(implementation = UserDto.class))),
+      @ApiResponse(responseCode = "204", description = "사용자 삭제 성공", content = @Content()),
       @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "404", description = "사용자 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
       @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  public ResponseEntity<UserDto> hardDelete(
+  public ResponseEntity<Void> hardDelete(
       @Parameter(description = "사용자 ID") @PathVariable UUID userId,
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
   ) {

--- a/src/main/java/com/codeit/monew/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/monew/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.codeit.monew.domain.user.repository;
 
 import com.codeit.monew.domain.user.entity.User;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByIdAndDeletedAtIsNull(UUID id);
 
   boolean existsByEmail(String email);
+
+  List<User> findByDeletedAtBefore(Instant threshold);
 }

--- a/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
@@ -19,11 +19,11 @@ public class UserScheduler {
   private final UserRepository userRepository;
 
   //크론 표현식으로 매일 0시 0분에 실행되도록 처리
-  @Scheduled(cron = "0 0 0 * * *")
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   @Transactional
   public void cleanUpUser() {
     Instant threshold = Instant.now().minus(Duration.ofDays(1));
-    log.info("[USER_CLEAN_UP] 논리 삭제 후 1일 지난 사용자 삭제 스케줄러 동작: 기준 사간={}", threshold);
+    log.info("[USER_CLEAN_UP] 논리 삭제 후 1일 지난 사용자 삭제 스케줄러 동작: 기준 시간={}", threshold);
     List<User> targets = userRepository.findByDeletedAtBefore(threshold);
     log.info("[USER_CLEAN_UP] 삭제 대상 사용자 수={}", targets.size());
     userRepository.deleteAllInBatch(targets);

--- a/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,33 @@
+package com.codeit.monew.domain.user.scheduler;
+
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class UserScheduler {
+
+  private final UserRepository userRepository;
+
+  //크론 표현식으로 매일 0시 0분에 실행되도록 처리
+  @Scheduled(cron = "0 0 0 * * *")
+  @Transactional
+  public void cleanUpUser() {
+    Instant threshold = Instant.now().minus(Duration.ofDays(1));
+    log.info("[USER_CLEAN_UP] 논리 삭제 후 1일 지난 사용자 삭제 스케줄러 동작: 기준 사간={}", threshold);
+    List<User> targets = userRepository.findByDeletedAtBefore(threshold);
+    log.info("[USER_CLEAN_UP] 삭제 대상 사용자 수={}", targets.size());
+    userRepository.deleteAllInBatch(targets);
+    log.info("[USER_CLEAN_UP] 물리 삭제 배치 완료");
+  }
+
+}

--- a/src/main/java/com/codeit/monew/domain/user/service/UserService.java
+++ b/src/main/java/com/codeit/monew/domain/user/service/UserService.java
@@ -58,25 +58,25 @@ public class UserService {
   }
 
   public void softDelete(UUID userId, UUID requestUserId) {
-    log.debug("[USER_UPDATE] 유저 논리 삭제 요청: userId={}", userId);
+    log.debug("[USER_DELETE] 유저 논리 삭제 요청: userId={}", userId);
 
     verifySameUser(userId, requestUserId);
 
     User user = userRepository.findByIdAndDeletedAtIsNull(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
     user.softDelete();
-    log.info("[USER_UPDATE] 유저 논리 삭제 완료: userId={}", user.getId());
+    log.info("[USER_DELETE] 유저 논리 삭제 완료: userId={}", user.getId());
   }
 
   public void hardDelete(UUID userId, UUID requestUserId) {
-    log.debug("[USER_UPDATE] 유저 물리 삭제 요청: userId={}", userId);
+    log.debug("[USER_DELETE] 유저 물리 삭제 요청: userId={}", userId);
 
     verifySameUser(userId, requestUserId);
 
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new UserNotFoundException(userId));
     userRepository.delete(user);
-    log.info("[USER_UPDATE] 유저 물리 삭제 완료: userId={}", user.getId());
+    log.info("[USER_DELETE] 유저 물리 삭제 완료: userId={}", user.getId());
   }
 
   private void verifySameUser(UUID userId, UUID requestUserId) {

--- a/src/main/java/com/codeit/monew/domain/user/service/UserService.java
+++ b/src/main/java/com/codeit/monew/domain/user/service/UserService.java
@@ -45,10 +45,7 @@ public class UserService {
   public UserDto update(UUID userId, UUID requestUserId, UserUpdateRequest request) {
     log.debug("[USER_UPDATE] 유저 수정 요청: userId={}", userId);
 
-    // URI에 포함된 userId와 헤더에 포함된 requestUserId를 비교해서 다르다면 예외를 던진다.
-    if (!userId.equals(requestUserId)) {
-      throw new UserAccessDeniedException(requestUserId);
-    }
+    verifySameUser(userId, requestUserId);
 
     // Soft Delete를 고려해 findByIdAndDeletedAtIsNull()을 호출
     User user = userRepository.findByIdAndDeletedAtIsNull(userId)
@@ -58,6 +55,35 @@ public class UserService {
 
     log.info("[USER_UPDATE] 유저 수정 완료: userId={}", user.getId());
     return userMapper.toDto(user);
+  }
+
+  public void softDelete(UUID userId, UUID requestUserId) {
+    log.debug("[USER_UPDATE] 유저 논리 삭제 요청: userId={}", userId);
+
+    verifySameUser(userId, requestUserId);
+
+    User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+    user.softDelete();
+    log.info("[USER_UPDATE] 유저 논리 삭제 완료: userId={}", user.getId());
+  }
+
+  public void hardDelete(UUID userId, UUID requestUserId) {
+    log.debug("[USER_UPDATE] 유저 물리 삭제 요청: userId={}", userId);
+
+    verifySameUser(userId, requestUserId);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserNotFoundException(userId));
+    userRepository.delete(user);
+    log.info("[USER_UPDATE] 유저 물리 삭제 완료: userId={}", user.getId());
+  }
+
+  private void verifySameUser(UUID userId, UUID requestUserId) {
+    // URI에 포함된 userId와 헤더에 포함된 requestUserId를 비교해서 다르다면 예외를 던진다.
+    if (!userId.equals(requestUserId)) {
+      throw new UserAccessDeniedException(requestUserId);
+    }
   }
 
   private void existsByEmail(String email) {

--- a/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
@@ -220,7 +220,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("논리 삭제할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
-    void should_fail_update_user_fail_when_user_not_found() throws Exception {
+    void should_fail_delete_user_fail_when_user_not_found() throws Exception {
       // given
       UUID userId = UUID.randomUUID();
 
@@ -270,7 +270,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("물리 삭제할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
-    void should_fail_update_user_fail_when_user_not_found() throws Exception {
+    void should_fail_delete_user_fail_when_user_not_found() throws Exception {
       // given
       UUID userId = UUID.randomUUID();
 

--- a/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/controller/UserControllerTest.java
@@ -2,6 +2,8 @@ package com.codeit.monew.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -107,7 +109,7 @@ class UserControllerTest {
   class updateUser {
 
     @Test
-    @DisplayName("유효한 요청 시 200 상태코드와 수정된 사용자 정보가 반환된다.")
+    @DisplayName("유효한 수정 요청 시 200 상태코드와 수정된 사용자 정보가 반환된다.")
     void should_update_user_success_and_return_200() throws Exception {
       // given
       UserUpdateRequest request = new UserUpdateRequest("newNickName");
@@ -177,6 +179,106 @@ class UserControllerTest {
               .header("Monew-Request-User-ID", userId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value(404));
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 논리 삭제 API 테스트")
+  class softDeleteUser {
+
+    @Test
+    @DisplayName("유효한 삭제 요청 시 204 상태코드가 반환된다.")
+    void should_delete_user_and_return_204() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      willDoNothing().given(userService).softDelete(userId, userId);
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 논리 삭제할 사용자의 ID가 다르면 403 상태 코드가 반환된다.")
+    void should_fail_delete_user_when_id_mismatch() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+
+      willThrow(new UserAccessDeniedException(requestUserId)).given(userService).softDelete(any(UUID.class), any(UUID.class));
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId)
+              .header("Monew-Request-User-ID", requestUserId))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("논리 삭제할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
+    void should_fail_update_user_fail_when_user_not_found() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      willThrow(new UserNotFoundException(userId)).given(userService).softDelete(any(UUID.class), any(UUID.class));
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId)
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value(404));
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 물리 삭제 API 테스트")
+  class hardDeleteUser {
+
+    @Test
+    @DisplayName("유효한 삭제 요청 시 204 상태코드가 반환된다.")
+    void should_delete_user_and_return_204() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      willDoNothing().given(userService).hardDelete(userId, userId);
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId + "/hard")
+              .header("Monew-Request-User-ID", userId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 물리 삭제할 사용자의 ID가 다르면 403 상태 코드가 반환된다.")
+    void should_fail_delete_user_when_id_mismatch() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+
+      willThrow(new UserAccessDeniedException(requestUserId)).given(userService).hardDelete(any(UUID.class), any(UUID.class));
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId + "/hard")
+              .header("Monew-Request-User-ID", requestUserId))
+          .andExpect(status().isForbidden())
+          .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("물리 삭제할 사용자가 존재하지 않으면 404 상태 코드가 반환된다.")
+    void should_fail_update_user_fail_when_user_not_found() throws Exception {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      willThrow(new UserNotFoundException(userId)).given(userService).hardDelete(any(UUID.class), any(UUID.class));
+
+      // when, then
+      mockMvc.perform(delete("/api/users/" + userId + "/hard")
+              .header("Monew-Request-User-ID", userId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.status").value(404));
     }

--- a/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
@@ -1,0 +1,44 @@
+package com.codeit.monew.domain.user.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserSchedulerTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private UserScheduler userScheduler;
+
+  @Test
+  @DisplayName("논리 삭제된 지 24시간이 지난 유저는 물리 삭제되어야 한다")
+  void should_hard_delete_users_when_soft_deleted_over_24_hours_ago() {
+    // given
+    User targetUser = new User("test@email.com", "testNickname", "testPassword1");
+    List<User> targets = List.of(targetUser);
+    given(userRepository.findByDeletedAtBefore(any(Instant.class))).willReturn(targets);
+
+    // when
+    userScheduler.cleanUpUser();
+
+    // then
+    verify(userRepository, times(1)).deleteAllInBatch(targets);
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
@@ -32,6 +32,7 @@ class UserSchedulerTest {
   void should_hard_delete_users_when_soft_deleted_over_24_hours_ago() {
     // given
     User targetUser = new User("test@email.com", "testNickname", "testPassword1");
+    targetUser.softDelete();
     List<User> targets = List.of(targetUser);
     given(userRepository.findByDeletedAtBefore(any(Instant.class))).willReturn(targets);
 

--- a/src/test/java/com/codeit/monew/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/service/UserServiceTest.java
@@ -160,4 +160,104 @@ class UserServiceTest {
       verify(userMapper, never()).toDto(any(User.class));
     }
   }
+
+  @Nested
+  @DisplayName("사용자 논리 삭제 테스트")
+  class softDeleteUser {
+
+    @Test
+    @DisplayName("사용자 논리 삭제에 성공해야 한다.")
+    void should_soft_delete_user_success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser(userId, "test@email.com", "testNickname",
+          "testPassword1!");
+
+      given(userRepository.findByIdAndDeletedAtIsNull(any(UUID.class))).willReturn(Optional.of(user));
+
+      // when
+      userService.softDelete(userId, userId);
+
+      // then
+      assertNotNull(user.getDeletedAt());
+      verify(userRepository).findByIdAndDeletedAtIsNull(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 UserNotFound 예외가 발생한다.")
+    void should_fail_soft_delete_user_when_user_not_found() {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      given(userRepository.findByIdAndDeletedAtIsNull(any(UUID.class))).willReturn(Optional.empty());
+
+      // when, then
+      UserNotFoundException exception = assertThrows(UserNotFoundException.class,
+          () -> userService.softDelete(userId, userId));
+      assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 수정할 사용자의 ID가 다르면 UserAccessDenied 예외가 발생한다.")
+    void should_fail_soft_delete_user_when_id_mismatch() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+
+      // when, then
+      UserAccessDeniedException exception = assertThrows(UserAccessDeniedException.class,
+          () -> userService.softDelete(userId, requestUserId));
+      assertEquals(ErrorCode.USER_ACCESS_DENIED, exception.getErrorCode());
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 물리 삭제 테스트")
+  class hardDeleteUser {
+
+    @Test
+    @DisplayName("사용자 물리 삭제에 성공해야 한다.")
+    void should_hard_delete_user_success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      User user = createUser(userId, "test@email.com", "testNickname",
+          "testPassword1!");
+
+      given(userRepository.findById(any(UUID.class))).willReturn(Optional.of(user));
+
+      // when
+      userService.hardDelete(userId, userId);
+
+      // then
+      verify(userRepository).findById(any(UUID.class));
+      verify(userRepository).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 UserNotFound 예외가 발생한다.")
+    void should_fail_hard_delete_user_when_user_not_found() {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      given(userRepository.findById(any(UUID.class))).willReturn(Optional.empty());
+
+      // when, then
+      UserNotFoundException exception = assertThrows(UserNotFoundException.class,
+          () -> userService.hardDelete(userId, userId));
+      assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("요청자 ID와 수정할 사용자의 ID가 다르면 UserAccessDenied 예외가 발생한다.")
+    void should_fail_hard_delete_user_when_id_mismatch() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID requestUserId = UUID.randomUUID();
+
+      // when, then
+      UserAccessDeniedException exception = assertThrows(UserAccessDeniedException.class,
+          () -> userService.hardDelete(userId, requestUserId));
+      assertEquals(ErrorCode.USER_ACCESS_DENIED, exception.getErrorCode());
+    }
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #32, #37

## 📝작업 내용
- 사용자의 논리 삭제와 물리 삭제 로직을 추가했습니다.
- 논리 삭제 후 1일 경과 시 물리 삭제를 진행하는 스케줄러를 추가하였습니다.
- 스케줄러의 주기는 매일 0시 0분에 작동하도록 설정했습니다.
- 삭제 로직 컨트롤러, 스케줄러, 서비스에 대한 테스트 코드를 작성했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 삭제 API 추가: 소프트 삭제(논리 삭제) 및 하드 삭제(물리 삭제) 엔드포인트 추가(성공 시 HTTP 204).
  * 스케줄링 활성화 및 자동 정리 스케줄러 추가: 매일 자정에 24시간 이상 소프트 삭제된 사용자 데이터 자동 제거.

* **테스트**
  * 삭제 관련 단위 테스트 추가 및 검증 보강(성공, 권한 오류(403), 미존재(404) 케이스).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->