### PR TITLE
[feat] 뉴스기사 수집 배치 구현 및 재시도 전략 추가

### DIFF
--- a/src/main/java/com/codeit/monew/domain/article/controller/AdminArticleController.java
+++ b/src/main/java/com/codeit/monew/domain/article/controller/AdminArticleController.java
@@ -1,7 +1,9 @@
 package com.codeit.monew.domain.article.controller;
 
 import com.codeit.monew.domain.article.dto.request.ArticleScrapeRequest;
+import com.codeit.monew.domain.article.dto.response.ArticleScrapeBatchRunResponse;
 import com.codeit.monew.domain.article.dto.response.ArticleScrapeResponse;
+import com.codeit.monew.domain.article.service.ArticleScrapeBatchRunner;
 import com.codeit.monew.domain.article.service.ArticleScrapeService;
 import com.codeit.monew.infra.external.rss.NewsSourceUrl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobExecutionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminArticleController {
 
   private final ArticleScrapeService articleScrapeService;
+  private final ArticleScrapeBatchRunner articleScrapeBatchRunner;
 
   @PostMapping("/scrape-test")
   @Operation(summary = "뉴스 기사 수집 테스트", description = "외부 RSS/네이버 API를 호출하여 기사를 수집하고 저장합니다.")
@@ -55,6 +59,27 @@ public class AdminArticleController {
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 
+  @PostMapping("/scrape-batch/run")
+  @Operation(summary = "뉴스 수집 배치 수동 실행", description = "Spring Batch 뉴스 수집 Job을 즉시 실행하고 Step별 결과를 반환합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "배치 실행 완료",
+          content = @Content(schema = @Schema(implementation = ArticleScrapeBatchRunResponse.class))),
+      @ApiResponse(responseCode = "500", description = "배치 실행 중 서버 오류")
+  })
+  public ResponseEntity<?> runScrapeBatch() {
+    try {
+      ArticleScrapeBatchRunResponse response = articleScrapeBatchRunner.runNow();
+      return ResponseEntity.ok(response);
+    } catch (JobExecutionException e) {
+      Map<String, Object> body = new HashMap<>();
+      body.put("timestamp", Instant.now());
+      body.put("code", "BATCH_EXECUTION_FAILED");
+      body.put("message", "뉴스 수집 배치 실행에 실패했습니다.");
+      body.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+    }
+  }
+
   private ResponseEntity<Map<String, Object>> badRequest(String message) {
     Map<String, Object> body = new HashMap<>();
     body.put("timestamp", Instant.now());
@@ -64,4 +89,3 @@ public class AdminArticleController {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
   }
 }
-

--- a/src/main/java/com/codeit/monew/domain/article/dto/response/ArticleScrapeBatchRunResponse.java
+++ b/src/main/java/com/codeit/monew/domain/article/dto/response/ArticleScrapeBatchRunResponse.java
@@ -1,0 +1,42 @@
+package com.codeit.monew.domain.article.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ArticleScrapeBatchRunResponse(
+    @Schema(description = "Batch Job Execution ID")
+    Long jobExecutionId,
+
+    @Schema(description = "Batch Job 상태", example = "COMPLETED")
+    String status,
+
+    @Schema(description = "Batch Job 시작 시각")
+    LocalDateTime startTime,
+
+    @Schema(description = "Batch Job 종료 시각")
+    LocalDateTime endTime,
+
+    @Schema(description = "Step별 실행 결과")
+    List<StepResult> steps
+) {
+
+  public record StepResult(
+      @Schema(description = "Step 이름", example = "rssStep")
+      String stepName,
+
+      @Schema(description = "Step 상태", example = "COMPLETED")
+      String status,
+
+      @Schema(description = "Step 종료 코드", example = "COMPLETED")
+      String exitCode,
+
+      @Schema(description = "commit 횟수")
+      long commitCount,
+
+      @Schema(description = "rollback 횟수")
+      long rollbackCount
+  ) {
+
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/ArticleScrapeBatchConfig.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/ArticleScrapeBatchConfig.java
@@ -1,0 +1,58 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ArticleScrapeBatchConfig {
+
+  public static final String JOB_NAME = "articleScrapeBatchJob";
+
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+  private final RssArticleBatchJob rssArticleBatchJob;
+  private final NaverArticleBatchJob naverArticleBatchJob;
+
+  @Bean
+  public Job articleScrapeBatchJob() {
+    return new JobBuilder(JOB_NAME, jobRepository)
+        .start(rssStep())
+        .next(naverStep())
+        .build();
+  }
+
+  @Bean
+  public Step rssStep() {
+    return new StepBuilder("rssStep", jobRepository)
+        .tasklet((contribution, chunkContext) -> {
+          Arrays.stream(NewsSourceUrl.values())
+              .filter(source -> source
+                  != NewsSourceUrl.NAVER) // 네이버를 제외한 NewsSourceUrl에 있는 모든 소스를 기준으로 배치 실행
+              .forEach(rssArticleBatchJob::run);
+          return RepeatStatus.FINISHED;
+        }, transactionManager)
+        .build();
+  }
+
+  @Bean
+  public Step naverStep() {
+    return new StepBuilder("naverStep", jobRepository)
+        .tasklet((contribution, chunkContext) -> {
+          naverArticleBatchJob.run();
+          return RepeatStatus.FINISHED;
+        }, transactionManager)
+        .build();
+  }
+
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/ArticleScrapeScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/ArticleScrapeScheduler.java
@@ -1,0 +1,26 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.domain.article.service.ArticleScrapeBatchRunner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArticleScrapeScheduler {
+
+  private final ArticleScrapeBatchRunner articleScrapeBatchRunner;
+
+  //크론 표현식으로 매 시각 0분에 실행되도록 처리
+  @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+  public void runHourly() {
+    try {
+      articleScrapeBatchRunner.runNow();
+    } catch (JobExecutionException e) {
+      log.error("[ARTICLE_SCHEDULER] hourly batch failed", e);
+    }
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
@@ -1,0 +1,106 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.domain.interest.repository.KeywordRepository;
+import com.codeit.monew.global.exception.external.ExternalClientException;
+import com.codeit.monew.global.exception.external.ExternalNetworkException;
+import com.codeit.monew.global.exception.external.ExternalRateLimitException;
+import com.codeit.monew.global.exception.external.ExternalServerException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverArticleBatchJob {
+
+  private static final long NAVER_REQUEST_DELAY_MS = 50L;               // 요청 간격
+  private static final int NAVER_RATE_LIMIT_MAX_RETRY = 5;              // 429, 재시도 최대 횟수
+  private static final long NAVER_RATE_LIMIT_BASE_DELAY_MS = 100L;      // 429, 재시도 요청 간격 * 시도 횟수
+  private static final int NAVER_SERVER_MAX_RETRY = 3;                  // 500, 재시도 최대 횟수
+  private static final long NAVER_SERVER_RETRY_BASE_DELAY_MS = 10_000L; // 500, 재시도 요청 간격 * 시도 횟수
+
+  private final NaverKeywordTxProcessor naverKeywordTxProcessor;
+  private final KeywordRepository keywordRepository;
+
+  public void run() {
+    Set<String> keywords = loadDistinctKeywordNames();
+    int total = keywords.size();
+    int index = 0;
+
+    log.info("[NAVER_BATCH] start. keywordCount={}", total);
+
+    for (String keyword : keywords) {
+      index++;
+      sleep(NAVER_REQUEST_DELAY_MS);
+      scrapeByKeyword(keyword, index, total);
+    }
+
+    log.info("[NAVER_BATCH] finished. keywordCount={}", total);
+  }
+
+  private void scrapeByKeyword(String keyword, int index, int total) {
+    int rateLimitAttempt = 0;
+    int serverAttempt = 0;
+
+    while (true) {
+      try {
+        int saved = naverKeywordTxProcessor.processOneKeyword(keyword);
+        log.info("[NAVER_BATCH] keyword={}/{} ({}) saved={}", index, total, keyword, saved);
+        return;
+      } catch (ExternalRateLimitException e) {
+        rateLimitAttempt++;
+        if (rateLimitAttempt > NAVER_RATE_LIMIT_MAX_RETRY) {
+          log.warn("[NAVER_BATCH] keyword={} rate-limit retry exhausted({})",
+              keyword, NAVER_RATE_LIMIT_MAX_RETRY, e);
+          return;
+        }
+        long waitMs = NAVER_RATE_LIMIT_BASE_DELAY_MS * rateLimitAttempt;
+        log.warn("[NAVER_BATCH] keyword={} 429 retry={}/{}, waitMs={}",
+            keyword, rateLimitAttempt, NAVER_RATE_LIMIT_MAX_RETRY, waitMs, e);
+        sleep(waitMs);
+      } catch (ExternalServerException | ExternalNetworkException e) {
+        serverAttempt++;
+        if (serverAttempt > NAVER_SERVER_MAX_RETRY) {
+          log.error("[NAVER_BATCH] keyword={} server retry exhausted({})",
+              keyword, NAVER_SERVER_MAX_RETRY, e);
+          return;
+        }
+        long waitMs = NAVER_SERVER_RETRY_BASE_DELAY_MS * serverAttempt;
+        log.warn("[NAVER_BATCH] keyword={} server retry={}/{}, waitMs={}",
+            keyword, serverAttempt, NAVER_SERVER_MAX_RETRY, waitMs, e);
+        sleep(waitMs);
+      } catch (ExternalClientException e) {
+        log.warn("[NAVER_BATCH] keyword={} client error, no retry", keyword, e);
+        return;
+      } catch (Exception e) {
+        // 예기치 못한 예외도 이 키워드만 실패 처리하고 다음 키워드로 진행
+        log.error("[NAVER_BATCH] keyword={} unexpected error, skip this keyword", keyword, e);
+        return;
+      }
+    }
+  }
+
+  private Set<String> loadDistinctKeywordNames() {
+    LinkedHashSet<String> result = new LinkedHashSet<>();
+    keywordRepository.findAllWithInterest().forEach(keyword -> {
+      String name = keyword.getName();
+      if (StringUtils.hasText(name)) {
+        result.add(name.trim());
+      }
+    });
+    return result;
+  }
+
+  private void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Naver batch sleep interrupted", e);
+    }
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/NaverKeywordTxProcessor.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/NaverKeywordTxProcessor.java
@@ -1,0 +1,20 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.domain.article.service.ArticleScrapeService;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NaverKeywordTxProcessor {
+
+  private final ArticleScrapeService articleScrapeService;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public int processOneKeyword(String keyword) {
+    return articleScrapeService.scrapeAndSave(NewsSourceUrl.NAVER, keyword);
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
@@ -1,0 +1,61 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.global.exception.external.ExternalClientException;
+import com.codeit.monew.global.exception.external.ExternalNetworkException;
+import com.codeit.monew.global.exception.external.ExternalRateLimitException;
+import com.codeit.monew.global.exception.external.ExternalServerException;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RssArticleBatchJob {
+
+  private static final int RSS_SERVER_MAX_RETRY = 3;                  // 500, 최대 재시도 횟수
+  private static final long RSS_SERVER_RETRY_BASE_DELAY_MS = 10_000L; // 500, 재시도 요청 간격 * attempt
+
+  private final RssSourceTxProcessor rssSourceTxProcessor;
+
+  public void run(NewsSourceUrl source) {
+    int attempt = 0;
+
+    while (true) {
+      try {
+        int saved = rssSourceTxProcessor.processOneSource(source);
+        log.info("[RSS_BATCH] source={}, saved={}", source, saved);
+        return;
+      } catch (ExternalRateLimitException e) {
+        log.warn("[RSS_BATCH] source={} rate-limited(429), skip until next batch", source, e);
+        return;
+      } catch (ExternalServerException | ExternalNetworkException e) {
+        attempt++;
+        if (attempt > RSS_SERVER_MAX_RETRY) {
+          log.error("[RSS_BATCH] source={} failed after retries", source, e);
+          return;
+        }
+        long waitMs = RSS_SERVER_RETRY_BASE_DELAY_MS * attempt;
+        log.warn("[RSS_BATCH] source={} transient failure, retry={}/{}, waitMs={}",
+            source, attempt, RSS_SERVER_MAX_RETRY, waitMs, e);
+        sleep(waitMs);
+      } catch (ExternalClientException e) {
+        log.warn("[RSS_BATCH] source={} client error, no retry", source, e);
+        return;
+      } catch (Exception e) {
+        log.error("[RSS_BATCH] source={} unexpected error, skip this source", source, e);
+        return;
+      }
+    }
+  }
+
+  private void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("RSS batch sleep interrupted", e);
+    }
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/RssSourceTxProcessor.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/RssSourceTxProcessor.java
@@ -1,0 +1,20 @@
+package com.codeit.monew.domain.article.scheduler;
+
+import com.codeit.monew.domain.article.service.ArticleScrapeService;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RssSourceTxProcessor {
+
+  private final ArticleScrapeService articleScrapeService;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public int processOneSource(NewsSourceUrl source) {
+    return articleScrapeService.scrapeAndSave(source, null);
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/article/service/ArticleScrapeBatchRunner.java
+++ b/src/main/java/com/codeit/monew/domain/article/service/ArticleScrapeBatchRunner.java
@@ -1,0 +1,61 @@
+package com.codeit.monew.domain.article.service;
+
+import com.codeit.monew.domain.article.dto.response.ArticleScrapeBatchRunResponse;
+import com.codeit.monew.domain.article.dto.response.ArticleScrapeBatchRunResponse.StepResult;
+import com.codeit.monew.domain.article.scheduler.ArticleScrapeBatchConfig;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArticleScrapeBatchRunner {
+
+  private final JobLauncher jobLauncher;
+  private final Job articleScrapeBatchJob;
+
+  public ArticleScrapeBatchRunner(
+      JobLauncher jobLauncher,
+      @Qualifier(ArticleScrapeBatchConfig.JOB_NAME) Job articleScrapeBatchJob
+  ) {
+    this.jobLauncher = jobLauncher;
+    this.articleScrapeBatchJob = articleScrapeBatchJob;
+  }
+
+  public ArticleScrapeBatchRunResponse runNow() throws JobExecutionException {
+    JobParameters params = new JobParametersBuilder()
+        .addLong("manualTriggeredAt", System.currentTimeMillis())
+        .toJobParameters();
+
+    JobExecution execution = jobLauncher.run(articleScrapeBatchJob, params);
+    return toResponse(execution);
+  }
+
+  private ArticleScrapeBatchRunResponse toResponse(JobExecution execution) {
+    List<StepResult> steps = execution.getStepExecutions().stream()
+        .sorted(Comparator.comparing(StepExecution::getStepName))
+        .map(step -> new StepResult(
+            step.getStepName(),
+            step.getStatus().name(),
+            step.getExitStatus().getExitCode(),
+            step.getCommitCount(),
+            step.getRollbackCount()
+        ))
+        .toList();
+
+    return new ArticleScrapeBatchRunResponse(
+        execution.getId(),
+        execution.getStatus().name(),
+        execution.getStartTime(),
+        execution.getEndTime(),
+        steps
+    );
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/monew/global/exception/ErrorCode.java
@@ -30,7 +30,14 @@ public enum ErrorCode {
 
   // Server 에러 코드
   INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다."),
-  INVALID_REQUEST("잘못된 요청입니다.");
+  INVALID_REQUEST("잘못된 요청입니다."),
+
+  // External 관련 에러 코드
+  EXTERNAL_CLIENT_ERROR("외부 연동 요청 오류가 발생했습니다."),
+  EXTERNAL_RATE_LIMITED("외부 연동 요청 제한이 발생했습니다."),
+  EXTERNAL_SERVER_ERROR("외부 연동 서버 오류가 발생했습니다."),
+  EXTERNAL_EMPTY_RESPONSE("외부 연동 응답 본문이 비어 있습니다."),
+  EXTERNAL_NETWORK_ERROR("외부 연동 네트워크 오류가 발생했습니다.");
 
   private final String message;
 

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,7 @@ package com.codeit.monew.global.exception;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,8 +11,6 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.View;
 
@@ -150,13 +148,17 @@ public class GlobalExceptionHandler {
 //            case  -> HttpStatus.BAD_REQUEST;
 //            case  -> HttpStatus.INTERNAL_SERVER_ERROR;
 
-      case USER_NOT_FOUND, ARTICLE_NOT_FOUND, COMMENT_NOT_FOUND, INTEREST_NOT_FOUND, SUBSCRIPTION_NOT_FOUND -> HttpStatus.NOT_FOUND;
+      case USER_NOT_FOUND, ARTICLE_NOT_FOUND, COMMENT_NOT_FOUND, INTEREST_NOT_FOUND,
+           SUBSCRIPTION_NOT_FOUND -> HttpStatus.NOT_FOUND;
       case PASSWORD_MISMATCH -> HttpStatus.UNAUTHORIZED;
       case DUPLICATE_EMAIL, DUPLICATE_INTEREST, ALREADY_SUBSCRIBED -> HttpStatus.CONFLICT;
       case USER_ACCESS_DENIED, COMMENT_UPDATE_FORBIDDEN -> HttpStatus.FORBIDDEN;
       case COMMENT_CONTENT_BLANK, COMMENT_CONTENT_TOO_LONG -> HttpStatus.BAD_REQUEST;
-
-      default -> HttpStatus.INTERNAL_SERVER_ERROR; // 지금은 디버깅 에러 잡는 용도, 나중에 지워야 함
+      case EXTERNAL_RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS; // 429
+      case EXTERNAL_CLIENT_ERROR -> HttpStatus.BAD_GATEWAY;      // 502
+      case EXTERNAL_SERVER_ERROR, EXTERNAL_EMPTY_RESPONSE, EXTERNAL_NETWORK_ERROR ->
+          HttpStatus.SERVICE_UNAVAILABLE; // 503
+      default -> HttpStatus.INTERNAL_SERVER_ERROR; // 500, 알수 없는 에러
     };
   }
 }

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalApiException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalApiException.java
@@ -1,0 +1,34 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.global.exception.MonewException;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import lombok.Getter;
+
+@Getter
+public abstract class ExternalApiException extends MonewException {
+
+  private final NewsSourceUrl source;
+  private final String url;
+  private final Integer statusCode;
+  private final boolean retryable;
+
+  protected ExternalApiException(
+      ErrorCode errorCode,
+      NewsSourceUrl source,
+      String url,
+      Integer statusCode,
+      boolean retryable,
+      Throwable cause
+  ) {
+    super(errorCode, cause);
+    this.source = source;
+    this.url = url;
+    this.statusCode = statusCode;
+    this.retryable = retryable;
+    addDetail("source", source);
+    addDetail("url", url);
+    addDetail("statusCode", statusCode);
+    addDetail("retryable", retryable);
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalClientException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalClientException.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+
+public class ExternalClientException extends ExternalApiException {
+
+  public ExternalClientException(NewsSourceUrl source, String url, int statusCode,
+      Throwable cause) {
+    super(ErrorCode.EXTERNAL_CLIENT_ERROR, source, url, statusCode, false, cause);
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalEmptyResponseException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalEmptyResponseException.java
@@ -1,0 +1,11 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+
+public class ExternalEmptyResponseException extends ExternalApiException {
+
+  public ExternalEmptyResponseException(NewsSourceUrl source, String url) {
+    super(ErrorCode.EXTERNAL_EMPTY_RESPONSE, source, url, null, false, null);
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalNetworkException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalNetworkException.java
@@ -1,0 +1,11 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+
+public class ExternalNetworkException extends ExternalApiException {
+
+  public ExternalNetworkException(NewsSourceUrl source, String url, Throwable cause) {
+    super(ErrorCode.EXTERNAL_NETWORK_ERROR, source, url, null, true, cause);
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalRateLimitException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalRateLimitException.java
@@ -1,0 +1,23 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import lombok.Getter;
+
+@Getter
+public class ExternalRateLimitException extends ExternalApiException {
+
+  private final boolean retryNextBatch;
+
+  public ExternalRateLimitException(
+      NewsSourceUrl source,
+      String url,
+      boolean retryableNow,
+      boolean retryNextBatch,
+      Throwable cause
+  ) {
+    super(ErrorCode.EXTERNAL_RATE_LIMITED, source, url, 429, retryableNow, cause);
+    this.retryNextBatch = retryNextBatch;
+    addDetail("retryNextBatch", retryNextBatch);
+  }
+}

--- a/src/main/java/com/codeit/monew/global/exception/external/ExternalServerException.java
+++ b/src/main/java/com/codeit/monew/global/exception/external/ExternalServerException.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.global.exception.external;
+
+import com.codeit.monew.global.exception.ErrorCode;
+import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+
+public class ExternalServerException extends ExternalApiException {
+
+  public ExternalServerException(NewsSourceUrl source, String url, int statusCode,
+      Throwable cause) {
+    super(ErrorCode.EXTERNAL_SERVER_ERROR, source, url, statusCode, true, cause);
+  }
+}

--- a/src/main/java/com/codeit/monew/infra/external/rss/XmlClient.java
+++ b/src/main/java/com/codeit/monew/infra/external/rss/XmlClient.java
@@ -1,10 +1,18 @@
 package com.codeit.monew.infra.external.rss;
 
+import com.codeit.monew.global.exception.external.ExternalClientException;
+import com.codeit.monew.global.exception.external.ExternalEmptyResponseException;
+import com.codeit.monew.global.exception.external.ExternalNetworkException;
+import com.codeit.monew.global.exception.external.ExternalRateLimitException;
+import com.codeit.monew.global.exception.external.ExternalServerException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Component
@@ -30,23 +38,38 @@ public class XmlClient {
   }
 
   private String request(NewsSourceUrl source, String url) {
-    String xml = restClient.get()
-        .uri(url)
-        .headers(headers -> {
-          headers.set("User-Agent", "Mozilla/5.0");
-          // 네이버의 경우 Header에 API 사용 신청에서 발급받은 Client ID와 Secret Key를 넣어줘야 함
-          if (source.isNaver()) {
-            headers.set("X-Naver-Client-Id", naverClientId);
-            headers.set("X-Naver-Client-Secret", naverClientSecret);
-          }
-        })
-        .retrieve()
-        .body(String.class);
+    try {
+      String xml = restClient.get()
+          .uri(url)
+          .headers(headers -> {
+            headers.set("User-Agent", "Mozilla/5.0");
+            if (source.isNaver()) {
+              headers.set("X-Naver-Client-Id", naverClientId);
+              headers.set("X-Naver-Client-Secret", naverClientSecret);
+            }
+          })
+          .retrieve()
+          .body(String.class);
 
-    if (xml == null || xml.isBlank()) {
-      // todo: 커스텀 예외로 전환 필요
-      throw new IllegalStateException("XML 응답이 비어 있습니다. source=" + source);
+      if (xml == null || xml.isBlank()) {
+        throw new ExternalEmptyResponseException(source, url);
+      }
+      return xml;
+
+    } catch (HttpClientErrorException.TooManyRequests e) {
+      throw new ExternalRateLimitException(
+          source,
+          url,
+          source == NewsSourceUrl.NAVER,   // NAVER는 같은 배치 재시도
+          source != NewsSourceUrl.NAVER,   // RSS는 다음 배치로
+          e
+      );
+    } catch (HttpClientErrorException e) {
+      throw new ExternalClientException(source, url, e.getStatusCode().value(), e);
+    } catch (HttpServerErrorException e) {
+      throw new ExternalServerException(source, url, e.getStatusCode().value(), e);
+    } catch (RestClientException e) {
+      throw new ExternalNetworkException(source, url, e);
     }
-    return xml;
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,12 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
   data:
     mongodb:
       uri: ${MONGO_PROTO:mongodb}://${MONGO_USER}:${MONGO_PASSWORD}@${MONGO_HOST:localhost}/${MONGO_DB:monew_dev}?authSource=admin&retryWrites=true&w=majority&appName=SB10-MONEW-TEAM5


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) Closes #75 , #102, #104 

## 📝작업 내용

뉴스 기사 수집 작업을 매 정각에 실행하도록 하였습니다.
그 외에 배치 작업도 관리자용 API를 통해 수동적으로 실행할 수 있는 코드를 작성하였습니다.
배치 작업 내에서 재시도 전략을 위해서 XmlClient에 대해서만 커스텀 예외를 일부 작성하였습니다.

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

배치 전략 구조입니다.
관리자 API로 직접 호출 또는 스케줄러가 매 정각에 BatchRunner 서비스를 실행합니다.
해당 서비스는 BatchConfig에 등록되어 있는 BatchJob을 수행합니다.
BatchJob은 RssStep, NaverStep으로 구현되어 있으며 RssStep은 네이버 소스를 제외한 나머지 소스를 모두 순회합니다.
NaverStep은 존재하는 키워드 별로 반복 수행합니다.

이 외에 TxProcessor는 각 step 내부 작업이 개별적인 트랜잭션을 가지고 있도록 하기 위해 분리된 클래스입니다.
