### PR TITLE
[feat] 관심사 구독/구독 취소/목록 조회 단위 테스트 진행

### DIFF
--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -1,6 +1,7 @@
 package com.codeit.monew.domain.interest.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.monew.domain.interest.dto.request.InterestUpdateRequest;
+import com.codeit.monew.domain.interest.dto.response.CursorPageResponseInterestDto;
 import com.codeit.monew.domain.interest.dto.response.InterestDto;
 import com.codeit.monew.domain.interest.dto.response.SubscriptionDto;
 import com.codeit.monew.domain.interest.entity.Interest;
@@ -174,6 +176,79 @@ class InterestServiceTest {
   }
 
   // 4. 관심사 목록 조회
+  @Nested
+  @DisplayName("관심사 목록 조회 테스트")
+  class getList {
+
+    @Test
+    @DisplayName("관심사 목록을 조회할 수 있다.")
+    void success_get_interest_list() {
+      // given
+      UUID userId = UUID.randomUUID();
+      UUID interestId = UUID.randomUUID();
+
+      InterestDto interestDto = new InterestDto(
+          interestId, "스포츠", List.of("축구", "야구"), 10L, false
+      );
+
+      CursorPageResponseInterestDto expected = new CursorPageResponseInterestDto(
+          List.of(interestDto),
+          null,
+          null,
+          1,
+          1L,
+          false
+      );
+
+      given(interestRepository.findInterests(
+          null, "name", "ASC", null, null, 10, userId
+      )).willReturn(expected);
+
+      // when
+      CursorPageResponseInterestDto result = interestService.getList(
+          null, "name", "ASC", null, null, 10, userId
+      );
+
+      // then
+      assertNotNull(result);
+      assertEquals(1, result.content().size());
+      assertEquals("스포츠", result.content().get(0).name());
+      assertFalse(result.hasNext());
+      verify(interestRepository).findInterests(
+          null, "name", "ASC", null, null, 10, userId
+      );
+    }
+
+    @Test
+    @DisplayName("검색어로 관심사 목록을 조회할 수 있다.")
+    void success_get_interest_list_with_keyword() {
+      // given
+      UUID userId = UUID.randomUUID();
+
+      CursorPageResponseInterestDto expected = new CursorPageResponseInterestDto(
+          List.of(),
+          null,
+          null,
+          0,
+          0L,
+          false
+      );
+
+      given(interestRepository.findInterests(
+          "없는검색어", "name", "ASC", null, null, 10, userId
+      )).willReturn(expected);
+
+      // when
+      CursorPageResponseInterestDto result = interestService.getList(
+          "없는검색어", "name", "ASC", null, null, 10, userId
+      );
+
+      // then
+      assertNotNull(result);
+      assertEquals(0, result.content().size());
+      assertFalse(result.hasNext());
+    }
+  }
 
   // 5. 관심사 구독
   @Nested

--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import com.codeit.monew.domain.interest.dto.request.InterestRegisterRequest;
 import com.codeit.monew.domain.interest.dto.request.InterestUpdateRequest;
 import com.codeit.monew.domain.interest.dto.response.InterestDto;
+import com.codeit.monew.domain.interest.dto.response.SubscriptionDto;
 import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.repository.InterestRepository;
 import com.codeit.monew.domain.interest.repository.KeywordRepository;
@@ -19,6 +20,7 @@ import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.Interest.DuplicateInterestException;
 import com.codeit.monew.global.exception.Interest.InterestNotFoundException;
+import com.codeit.monew.global.exception.Interest.SubscriptionNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -173,6 +175,108 @@ class InterestServiceTest {
 
   // 4. 관심사 목록 조회
 
-  // 5. 관심사 구독/구독 취소
+  // 5. 관심사 구독
+  @Nested
+  @DisplayName("관심사 구독 테스트")
+  class subscribe {
+    @Test
+    @DisplayName("관심사를 구독할 수 있다.")
+    void success_subscribe_interest() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      Interest interest = createInterest(interestId, "스포츠");
+      User user = new User("test@email.com", "testNickname", "testPassword");
+      ReflectionTestUtils.setField(user, "id", userId);
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+      given(subscriptionRepository.save(any())).willAnswer(i -> i.getArgument(0));
+
+      // when
+      SubscriptionDto result = interestService.subscribe(interestId, userId);
+
+      // then
+      assertNotNull(result);
+      assertEquals(interestId, result.interestId());
+      verify(subscriptionRepository).save(any());
+      verify(interestRepository).incrementSubscriberCount(interestId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 관심사를 구독하면 실패한다.")
+    void fail_subscribe_when_interest_not_found() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(InterestNotFoundException.class,
+          () -> interestService.subscribe(interestId, userId));
+
+      verify(subscriptionRepository, never()).save(any());
+    }
+  }
+
+  // 6. 관심사 구독 취소
+  @Nested
+  @DisplayName("관심사 구독 취소 테스트")
+  class unsubscribe {
+    @Test
+    @DisplayName("관심사 구독을 취소할 수 있다.")
+    void success_unsubscribe_interest() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      Interest interest = createInterest(interestId, "스포츠");
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(1L);
+
+      // when
+      interestService.unsubscribe(interestId, userId);
+
+      // then
+      verify(subscriptionRepository).deleteByUserIdAndInterestId(userId, interestId);
+      verify(interestRepository).decrementSubscriberCount(interestId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 관심사를 구독 취소하면 실패한다.")
+    void fail_unsubscribe_when_interest_not_found() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+
+      // when, then
+      assertThrows(InterestNotFoundException.class,
+          () -> interestService.unsubscribe(interestId, userId));
+
+      verify(subscriptionRepository, never()).deleteByUserIdAndInterestId(any(), any());
+    }
+
+    @Test
+    @DisplayName("구독 중이지 않은 구독 취소하면 실패한다.")
+    void fail_unsubscribe_when_not_subscribed() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      Interest interest = createInterest(interestId, "스포츠");
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(0L);
+
+      // when, then
+      assertThrows(SubscriptionNotFoundException.class,
+          () -> interestService.unsubscribe(interestId, userId));
+
+      verify(interestRepository, never()).decrementSubscriberCount(any());
+    }
+
+  }
 
 }

--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -20,9 +20,11 @@ import com.codeit.monew.domain.interest.repository.KeywordRepository;
 import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.exception.Interest.AlreadySubscribedException;
 import com.codeit.monew.global.exception.Interest.DuplicateInterestException;
 import com.codeit.monew.global.exception.Interest.InterestNotFoundException;
 import com.codeit.monew.global.exception.Interest.SubscriptionNotFoundException;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -292,6 +295,30 @@ class InterestServiceTest {
           () -> interestService.subscribe(interestId, userId));
 
       verify(subscriptionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미 구독 중인 관심사를 구독하면 실패한다.")
+    void fail_subscribe_when_already_subscribed() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      Interest interest = createInterest(interestId, "스포츠");
+      User user = new User("test@email.com", "testNickname", "testPassword");
+      ReflectionTestUtils.setField(user, "id", userId);
+
+      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+      // DB UNIQUE 제약 위반 Mock
+      SQLException sqlException = new SQLException("중복 구독", "23505");
+      DataIntegrityViolationException exception =
+          new DataIntegrityViolationException("중복", sqlException);
+      given(subscriptionRepository.save(any())).willThrow(exception);
+
+      // when, then
+      assertThrows(AlreadySubscribedException.class,
+          () -> interestService.subscribe(interestId, userId));
     }
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#87 #88

## 📝작업 내용

- 관심사 구독 단위 테스트 진행
- 관심사 구독 취소 단위 테스트 진행
- 관심사 목록 조회 단위 테스트 진행

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 이후 관심사 목록 조회에 대한 통합 테스트 진행 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 관심사 조회(getList), 구독(subscribe), 구독 취소(unsubscribe)에 대한 단위 테스트 커버리지를 대폭 확장했습니다. 정상 흐름과 예외 처리(관심사 미존재, 이미 구독됨, 구독 미존재 등)를 검증하는 시나리오를 추가했습니다.

---

**사용자에게 영향을 주는 변경사항은 없습니다. 이번 업데이트는 내부 테스트 및 안정성 개선입니다.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->