### PR TITLE
[feat] 뉴스 기사 논리/물리 삭제 구현

### DIFF
--- a/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -124,5 +125,35 @@ public class ArticleController {
     ArticleViewDto response = articleService.view(articleId, requestUserId);
 
     return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+
+  @DeleteMapping(value = "/{articleId}")
+  @Operation(summary = "뉴스 기사 논리 삭제", description = "뉴스 기사를 논리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "논리 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "뉴스 기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<Void> delete(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable UUID articleId
+  ) {
+    articleService.delete(articleId);
+
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @DeleteMapping(value = "/{articleId}/hard")
+  @Operation(summary = "뉴스 기사 물리 삭제", description = "뉴스 기사를 물리적으로 삭제합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "뉴스 기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  public ResponseEntity<Void> hardDelete(
+      @Parameter(description = "뉴스 기사 ID") @PathVariable UUID articleId
+  ) {
+    articleService.hardDelete(articleId);
+
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -83,8 +83,8 @@ public class ArticleController {
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requestUserId
   ) {
     String keyword = request.getKeyword();
-    Instant publishDateFrom = request.getPublishDateFrom();
-    Instant publishDateTo = request.getPublishDateTo();
+    LocalDateTime publishDateFrom = request.getPublishDateFrom();
+    LocalDateTime publishDateTo = request.getPublishDateTo();
 
     // keyword 정규화
     // `strip` 이 `trim` 보다 `\n`(줄바꿈) `\t`(탭) 같은 유니코드 공백까지 잘 처리. 단, java 11이상

--- a/src/main/java/com/codeit/monew/domain/article/dto/request/ArticleSearchRequest.java
+++ b/src/main/java/com/codeit/monew/domain/article/dto/request/ArticleSearchRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -28,10 +29,10 @@ public class ArticleSearchRequest {
   private List<ArticleSource> sourceIn;
 
   @Parameter(description = "날짜 시작(범위)")
-  private Instant publishDateFrom;
+  private LocalDateTime publishDateFrom;
 
   @Parameter(description = "날짜 끝(범위)")
-  private Instant publishDateTo;
+  private LocalDateTime publishDateTo;
 
   @Parameter(description = "정렬 속성 이름", required = true)
   @NotNull(message = "정렬 속성은 필수입니다.")

--- a/src/main/java/com/codeit/monew/domain/article/entity/Article.java
+++ b/src/main/java/com/codeit/monew/domain/article/entity/Article.java
@@ -37,7 +37,7 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-@SQLDelete(sql = "UPDATE articles SET deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND version = ?")
+@SQLDelete(sql = "UPDATE articles SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL") // 조회 시 deleted_at이 null인 데이터만 가져오도록 글로벌 필터링
 public class Article extends BaseUpdatableEntity {
 

--- a/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, UUID>, ArticleQueryRepository {
 
@@ -18,4 +20,11 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
   // 논리 삭제된 기사 포함
   @Query(value = "SELECT EXISTS (SELECT 1 FROM articles WHERE source_url = :sourceUrl)", nativeQuery = true)
   boolean existsBySourceUrl(String sourceUrl);
+
+  // 뉴스 기사 물리 삭제
+  // `@SQLRestriction`로 조회 시 deletedAt이 null인 데이터만 가져오도록 필터링하기 때문에
+  // `void` 가 아닌 `int` 로 값을 반환해 id가 존재하는 기사인지 검증도 같이함
+  @Modifying // 조회 쿼리가 아님을 JPA에게 명시
+  @Query("DELETE FROM Article AS a WHERE a.id = :articleId")
+  int hardDelete(@Param("articleId") UUID articleId);
 }

--- a/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/ArticleRepository.java
@@ -25,6 +25,6 @@ public interface ArticleRepository extends JpaRepository<Article, UUID>, Article
   // `@SQLRestriction`로 조회 시 deletedAt이 null인 데이터만 가져오도록 필터링하기 때문에
   // `void` 가 아닌 `int` 로 값을 반환해 id가 존재하는 기사인지 검증도 같이함
   @Modifying // 조회 쿼리가 아님을 JPA에게 명시
-  @Query("DELETE FROM Article AS a WHERE a.id = :articleId")
+  @Query(value = "DELETE FROM articles AS a WHERE a.id = :articleId", nativeQuery = true)
   int hardDelete(@Param("articleId") UUID articleId);
 }

--- a/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
@@ -19,6 +19,8 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.UUID;
@@ -236,13 +238,25 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   private BooleanExpression[] commonWhere(ArticleSearchRequest request, QArticle article,
       QArticleInterest articleInterest) {
 
+    ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+    LocalDateTime publishDateFrom = request.getPublishDateFrom();
+    LocalDateTime publishDateTo = request.getPublishDateTo();
+
+    Instant fromInstant = publishDateFrom != null
+        ? publishDateFrom.atZone(zoneId).toInstant()
+        : null;
+    Instant toInstant = publishDateTo != null
+        ? publishDateTo.atZone(zoneId).toInstant()
+        : null;
+
     return new BooleanExpression[]{
         article.deletedAt.isNull(),
         keywordContains(article, request.getKeyword()),
         interestIdEq(articleInterest, request.getInterestId()),
         sourceIn(article, request.getSourceIn()),
-        publishDateGoe(article, request.getPublishDateFrom()),
-        publishDateLoe(article, request.getPublishDateTo())
+        publishDateGoe(article, fromInstant),
+        publishDateLoe(article, toInstant)
     };
   }
 

--- a/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
+++ b/src/main/java/com/codeit/monew/domain/article/service/ArticleService.java
@@ -149,4 +149,33 @@ public class ArticleService {
         article.getId());
     return articleViewMapper.toDto(articleViewHistory, article, user, commentCount, viewCount);
   }
+
+  // 뉴스 기사 논리 삭제
+  public void delete(UUID articleId) {
+    log.debug("[ARTICLE_SOFT_DELETE] 뉴스 기사 논리 삭제 시작: articleId={}", articleId);
+
+    // 뉴스 기사 존재 검증
+    Article article = articleRepository.findByIdAndDeletedAtIsNull(articleId)
+        .orElseThrow(() -> new ArticleNotFoundException(articleId));
+
+    // 논리 삭제 (`@SQLDelete`로 인해 `delete` 사용 시 `deletedAt` 이 업데이트 됨)
+    articleRepository.delete(article);
+
+    log.info("[ARTICLE_SOFT_DELETE] 뉴스 기사 논리 삭제 완료: articleId={}", articleId);
+  }
+
+  // 뉴스 기사 물리 삭제
+  public void hardDelete(UUID articleId) {
+    log.debug("[ARTICLE_HARD_DELETE] 뉴스 기사 물리 삭제 시작: articleId={}", articleId);
+
+    // `@SQLDelete`로 인해 `delete` 사용 시 삭제가 아닌 `deletedAt` 이 업데이트 됨
+    // `@SQLRestriction`로 조회 시 deletedAt이 null인 데이터만 가져오도록 필터링하기 때문에
+    // `void` 가 아닌 `int` 로 값을 반환해 id가 존재하는 기사인지 검증도 같이함
+    int deletedCount = articleRepository.hardDelete(articleId);
+    if (deletedCount == 0) { // 뉴스 기사 존재 검증
+      throw new ArticleNotFoundException(articleId);
+    }
+
+    log.info("[ARTICLE_HARD_DELETE] 뉴스 기사 물리 삭제 완료: articleId={}", articleId);
+  }
 }

--- a/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
@@ -445,7 +445,7 @@ class ArticleControllerTest {
       UUID articleId = UUID.randomUUID();
 
       willThrow(new ArticleNotFoundException(articleId)).given(articleService).delete(articleId);
-      
+
       // when(실행), then(검증)
       mockMvc.perform(delete("/api/articles/{articleId}", articleId))
           .andExpect(status().isNotFound())
@@ -461,7 +461,7 @@ class ArticleControllerTest {
   class hardDelete {
 
     @Test
-    @DisplayName("뉴스 기사 논리 삭제하면 204 상태코드를 반환한다.")
+    @DisplayName("뉴스 기사 물리 삭제하면 204 상태코드를 반환한다.")
     void success_hard_delete_article() throws Exception {
       // given(준비)
       UUID articleId = UUID.randomUUID();

--- a/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
@@ -264,14 +264,14 @@ class ArticleControllerTest {
     }
 
     @Test
-    @DisplayName("keyword가 공백일 경우 400 상태코드와 MethodArgumentNotValidException 예외 발생")
+    @DisplayName("keyword가 공백이 연속될 경우 400 상태코드와 MethodArgumentNotValidException 예외 발생")
     void fail_search_article_list_when_keyword_is_not_blank() throws Exception {
       // given(준비)
       UUID requestUserId = UUID.randomUUID();
 
       // when(시작), then(검증)
       mockMvc.perform(get("/api/articles")
-              .param("keyword", "")
+              .param("keyword", " ")
               .param("orderBy", ArticleOrderBy.publishDate.toString())
               .param("direction", ArticleDirection.DESC.toString())
               .param("limit", "5")

--- a/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/controller/ArticleControllerTest.java
@@ -38,8 +38,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -417,6 +418,77 @@ class ArticleControllerTest {
           .andExpect(
               jsonPath("$.exceptionType").value(ArticleNotFoundException.class.getSimpleName()))
           .andExpect(jsonPath("$.details.articleId").value(articleId.toString()));
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스 기사 논리 삭제 API 테스트")
+  class delete {
+
+    @Test
+    @DisplayName("뉴스 기사 논리 삭제하면 204 상태코드를 반환한다.")
+    void success_soft_delete_article() throws Exception {
+      // given(준비)
+      UUID articleId = UUID.randomUUID();
+
+      willDoNothing().given(articleService).delete(articleId);
+
+      // when(실행), then(검증)
+      mockMvc.perform(delete("/api/articles/{articleId}", articleId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("뉴스 기사 ID를 찾을 수 없을 경우 404 상태코드와 ArticleNotFoundException 예외 발생")
+    void fail_soft_delete_article_when_article_not_found() throws Exception {
+      // given(준비)
+      UUID articleId = UUID.randomUUID();
+
+      willThrow(new ArticleNotFoundException(articleId)).given(articleService).delete(articleId);
+      
+      // when(실행), then(검증)
+      mockMvc.perform(delete("/api/articles/{articleId}", articleId))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.toString()))
+          .andExpect(jsonPath("$.status").value(404))
+          .andExpect(
+              jsonPath("$.exceptionType").value(ArticleNotFoundException.class.getSimpleName()));
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스 기사 물리 삭제 API 테스트")
+  class hardDelete {
+
+    @Test
+    @DisplayName("뉴스 기사 논리 삭제하면 204 상태코드를 반환한다.")
+    void success_hard_delete_article() throws Exception {
+      // given(준비)
+      UUID articleId = UUID.randomUUID();
+
+      willDoNothing().given(articleService).hardDelete(articleId);
+
+      // when(실행), then(검증)
+      mockMvc.perform(delete("/api/articles/{articleId}/hard", articleId))
+          .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("뉴스 기사 ID를 찾을 수 없을 경우 404 상태코드와 ArticleNotFoundException 예외 발생")
+    void fail_hard_delete_article_when_article_not_found() throws Exception {
+      // given(준비)
+      UUID articleId = UUID.randomUUID();
+
+      willThrow(new ArticleNotFoundException(articleId)).given(articleService)
+          .hardDelete(articleId);
+
+      // when(실행), then(검증)
+      mockMvc.perform(delete("/api/articles/{articleId}/hard", articleId))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.toString()))
+          .andExpect(jsonPath("$.status").value(404))
+          .andExpect(
+              jsonPath("$.exceptionType").value(ArticleNotFoundException.class.getSimpleName()));
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/repository/ArticleRepositoryTest.java
@@ -9,6 +9,7 @@ import com.codeit.monew.global.config.JpaAuditingConfig;
 import com.codeit.monew.global.config.QueryDslConfig;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,5 +64,36 @@ class ArticleRepositoryTest {
 
     // then(검증)
     assertThat(result).containsExactly(ArticleSource.CHOSUN, ArticleSource.NAVER);
+  }
+
+  @Test
+  @DisplayName("저장된 뉴스 기사를 삭제하면 정수 1을 반환한다.")
+  void hardDelete() {
+    // given(준비)
+    Article article = createArticle(ArticleSource.NAVER, "https://naver.com", "title",
+        Instant.now(), "summary");
+
+    // 영속성 해제
+    testEntityManager.flush();
+    testEntityManager.clear();
+
+    // when(실행)
+    int result = articleRepository.hardDelete(article.getId());
+
+    // then(검증)
+    assertThat(result).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("저장되지 않은 뉴스 기사에 대한 삭제 시도 시 정수 0을 반환한다.")
+  void hardDelete_when_article_not_found() {
+    // given(준비)
+    UUID articleId = UUID.randomUUID();
+
+    // when(실행)
+    int result = articleRepository.hardDelete(articleId);
+
+    // then(검증)
+    assertThat(result).isEqualTo(0);
   }
 }

--- a/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
@@ -477,4 +477,83 @@ class ArticleServiceTest {
           any(User.class), anyLong(), anyLong());
     }
   }
+
+  @Nested
+  @DisplayName("뉴스 기사 논리 삭제 테스트")
+  class delete {
+
+    @Test
+    @DisplayName("논리 삭제되지 않은 뉴스 기사 ID로 해당 뉴스 기사를 논리 삭제할 수 있다.")
+    void success_soft_delete_by_articleId() {
+      // give(준비)
+      UUID articleId = UUID.randomUUID();
+      Article article = createArticle(articleId, ArticleSource.NAVER, "https://naver.com", "title",
+          Instant.now(), "summary");
+
+      given(articleRepository.findByIdAndDeletedAtIsNull(articleId)).willReturn(
+          Optional.of(article));
+
+      // when(준비)
+      articleService.delete(articleId);
+
+      // then(검증)
+      verify(articleRepository).findByIdAndDeletedAtIsNull(articleId);
+      verify(articleRepository).delete(article);
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않거나 논리 삭제된 뉴스 기사 ID가 조회되면 404 상태코드와 ArticleNotFoundException 예외가 발생한다.")
+    void fail_soft_delete_by_articleId_when_article_not_found() {
+      // give(준비)
+      UUID articleId = UUID.randomUUID();
+      Article article = createArticle(articleId, ArticleSource.NAVER, "https://naver.com", "title",
+          Instant.now(), "summary");
+
+      given(articleRepository.findByIdAndDeletedAtIsNull(articleId)).willReturn(Optional.empty());
+
+      // when(준비), then(검증)
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.delete(articleId));
+
+      verify(articleRepository).findByIdAndDeletedAtIsNull(articleId);
+      verify(articleRepository, never()).delete(article);
+    }
+  }
+
+  @Nested
+  @DisplayName("뉴스 기사 물리 삭제 테스트")
+  class hardDelete {
+
+    @Test
+    @DisplayName("뉴스 기사 ID로 해당 뉴스 기사를 물리 삭제할 수 있다.")
+    void success_hard_delete_by_articleId() {
+      // give(준비)
+      UUID articleId = UUID.randomUUID();
+
+      given(articleRepository.hardDelete(articleId)).willReturn(1);
+
+      // when(준비)
+      articleService.hardDelete(articleId);
+
+      // then(검증)
+      verify(articleRepository).hardDelete(articleId);
+    }
+
+
+    @Test
+    @DisplayName("존재하지 않은 뉴스 기사 ID가 조회되면 404 상태코드와 ArticleNotFoundException 예외가 발생한다.")
+    void fail_hard_delete_by_articleId_when_article_not_found() {
+      // give(준비)
+      UUID articleId = UUID.randomUUID();
+
+      given(articleRepository.hardDelete(articleId)).willReturn(0);
+
+      // when(준비), then(검증)
+      assertThrows(ArticleNotFoundException.class,
+          () -> articleService.hardDelete(articleId));
+
+      verify(articleRepository).hardDelete(articleId);
+    }
+  }
 }

--- a/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
@@ -493,7 +493,7 @@ class ArticleServiceTest {
       given(articleRepository.findByIdAndDeletedAtIsNull(articleId)).willReturn(
           Optional.of(article));
 
-      // when(준비)
+      // when(실행)
       articleService.delete(articleId);
 
       // then(검증)
@@ -512,7 +512,7 @@ class ArticleServiceTest {
 
       given(articleRepository.findByIdAndDeletedAtIsNull(articleId)).willReturn(Optional.empty());
 
-      // when(준비), then(검증)
+      // when(실행), then(검증)
       assertThrows(ArticleNotFoundException.class,
           () -> articleService.delete(articleId));
 
@@ -533,7 +533,7 @@ class ArticleServiceTest {
 
       given(articleRepository.hardDelete(articleId)).willReturn(1);
 
-      // when(준비)
+      // when(실행)
       articleService.hardDelete(articleId);
 
       // then(검증)
@@ -549,7 +549,7 @@ class ArticleServiceTest {
 
       given(articleRepository.hardDelete(articleId)).willReturn(0);
 
-      // when(준비), then(검증)
+      // when(실행), then(검증)
       assertThrows(ArticleNotFoundException.class,
           () -> articleService.hardDelete(articleId));
 


### PR DESCRIPTION
## 📝작업 내용

- 뉴스 기사 논리 삭제 구현
  - Controller, Service 로직 구현
- 뉴스 기사 물리 삭제 구현
  - Controller, Service, Repository 구현

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## #️⃣연관된 이슈

Closes #56 
Closes #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시물 삭제 기능 추가 — 논리 삭제(soft) 및 물리 삭제(hard) 지원, 삭제 요청에 대해 적절한 응답(204/404) 반환

* **Improvements**
  * 검색에서 게시물 공개일 필터의 날짜 타입 및 지역시간(한국 표준시) 처리 방식 개선

* **Tests**
  * 삭제 기능 관련 단위/통합 테스트 및 경계 시나리오 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->