### PR TITLE
[feat] 댓글 목록 조회 로직 구현

### DIFF
--- a/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/monew/domain/comment/controller/CommentController.java
@@ -1,8 +1,10 @@
 package com.codeit.monew.domain.comment.controller;
 
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
 import com.codeit.monew.domain.comment.dto.CommentDto;
 import com.codeit.monew.domain.comment.dto.CommentRegisterRequest;
 import com.codeit.monew.domain.comment.dto.CommentUpdateRequest;
+import com.codeit.monew.domain.comment.dto.CursorPageResponseCommentDto;
 import com.codeit.monew.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,15 +47,11 @@ public class CommentController {
   public ResponseEntity<CommentDto> registerComment(
       @Valid @RequestBody CommentRegisterRequest request) {
 
-    log.debug("댓글 등록 요청 수신");
-
     CommentDto response = commentService.registerComment(
         request.articleId(),
         request.userId(),
         request.content()
     );
-
-    log.info("댓글 등록 성공: 생성된 commentId= {}", response.id());
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -70,11 +70,7 @@ public class CommentController {
       @Parameter(description = "요청자 ID") @RequestHeader("Monew-Request-User-ID") UUID requesterId,
       @Valid @RequestBody CommentUpdateRequest request) {
 
-    log.debug("댓글 수정 요청 수신");
-
     CommentDto response = commentService.updateComment(commentId, requesterId, request.content());
-
-    log.info("댓글 수정 성공: 수정된 commentId= {}", response.id());
 
     return ResponseEntity.ok(response);
   }
@@ -87,8 +83,6 @@ public class CommentController {
   })
   @DeleteMapping("/{commentId}")
   public ResponseEntity<Void> deleteComment(@PathVariable UUID commentId) {
-
-    log.debug("댓글 논리 삭제 요청: commentId={}", commentId);
 
     commentService.deleteComment(commentId);
     return ResponseEntity.noContent().build();
@@ -103,9 +97,29 @@ public class CommentController {
   @DeleteMapping("/{commentId}/hard")
   public ResponseEntity<Void> hardDeleteComment(@PathVariable UUID commentId) {
 
-    log.debug("댓글 물리 삭제 요청: commentId={}", commentId);
-
     commentService.hardDeleteComment(commentId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "댓글 목록 조회", description = "조건에 맞는 댓글 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 (정렬 기준 오류, 페이지네이션 파라미터 오류 등)"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping
+  public ResponseEntity<CursorPageResponseCommentDto> getComments(
+      @Parameter(description = "요청자 ID", required = true)
+      @RequestHeader("Monew-Request-User-ID") UUID requesterId,
+
+      @Valid @ModelAttribute CommentCursorRequest request) {
+
+    CursorPageResponseCommentDto response = commentService.getCommentList(
+        request.articleId(),
+        requesterId,
+        request
+    );
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
@@ -14,21 +14,21 @@ public record CommentCursorRequest(
     @NotNull(message = "기사 ID는 필수입니다.")
     UUID articleId,
 
-    @Parameter(description = "정렬 기준 (createdAt: 최신순, likeCount: 좋아요순)", example = "createdAt")
+    @Parameter(description = "정렬 기준 (createdAt: 최신순, likeCount: 좋아요순)")
     @Pattern(regexp = "^(createdAt|likeCount)$", message = "정렬 기준은 createdAt 또는 likeCount여야 합니다.")
     String orderBy,
 
-    @Parameter(description = "정렬 방향 (ASC: 오름차순, DESC: 내림차순)", example = "DESC")
+    @Parameter(description = "정렬 방향 (ASC: 오름차순, DESC: 내림차순)")
     @Pattern(regexp = "^(ASC|DESC)$", message = "정렬 방향은 ASC 또는 DESC여야 합니다.")
     String direction,
 
-    @Parameter(description = "커서 값 (주 정렬 기준의 마지막 값)", example = "10")
+    @Parameter(description = "커서 값 (주 정렬 기준의 마지막 값)")
     String cursor,
 
-    @Parameter(description = "보조 커서 값 (createdAt, 동점자 처리용)", example = "2026-04-21T05:56:10.574Z")
+    @Parameter(description = "보조 커서 값 (createdAt, 동점자 처리용)")
     Instant after,
 
-    @Parameter(description = "한 페이지에 불러올 개수 (최대 100)", example = "10")
+    @Parameter(description = "한 페이지에 불러올 개수 (최대 100)")
     @Min(value = 1, message = "최소 1개 이상 조회해야 합니다.")
     @Max(value = 100, message = "최대 100개까지 조회 가능합니다.")
     Integer limit

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
@@ -1,0 +1,42 @@
+package com.codeit.monew.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.time.Instant;
+import java.util.UUID;
+
+// 댓글 목록 조회 요청 dto
+public record CommentCursorRequest(
+    @Parameter(description = "기사 ID", required = true)
+    @NotNull(message = "기사 ID는 필수입니다.")
+    UUID articleId,
+
+    @Parameter(description = "정렬 기준 (createdAt: 최신순, likeCount: 좋아요순)", example = "createdAt")
+    @Pattern(regexp = "^(createdAt|likeCount)$", message = "정렬 기준은 createdAt 또는 likeCount여야 합니다.")
+    String orderBy,
+
+    @Parameter(description = "정렬 방향 (ASC: 오름차순, DESC: 내림차순)", example = "DESC")
+    @Pattern(regexp = "^(ASC|DESC)$", message = "정렬 방향은 ASC 또는 DESC여야 합니다.")
+    String direction,
+
+    @Parameter(description = "커서 값 (주 정렬 기준의 마지막 값)", example = "10")
+    String cursor,
+
+    @Parameter(description = "보조 커서 값 (createdAt, 동점자 처리용)", example = "2026-04-21T05:56:10.574Z")
+    Instant after,
+
+    @Parameter(description = "한 페이지에 불러올 개수 (최대 100)", example = "10")
+    @Min(value = 1, message = "최소 1개 이상 조회해야 합니다.")
+    @Max(value = 100, message = "최대 100개까지 조회 가능합니다.")
+    Integer limit
+) {
+  // 컴팩트 생성자를 통한 기본값 설정
+  public CommentCursorRequest {
+    if (orderBy == null) orderBy = "createdAt";
+    if (direction == null) direction = "DESC";
+    if (limit == null) limit = 10;
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CursorPageResponseCommentDto.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CursorPageResponseCommentDto.java
@@ -1,0 +1,28 @@
+package com.codeit.monew.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "커서 기반 페이지 응답")
+public record CursorPageResponseCommentDto(
+
+    @Schema(description = "조회된 댓글 목록")
+    List<CommentDto> content,
+
+    @Schema(description = "커서 값")
+    String nextCursor,
+
+    @Schema(description = "보조 커서(createdAt) 값")
+    Instant nextAfter,
+
+    @Schema(description = "커서 페이지 크기")
+    int size,
+
+    @Schema(description = "전체 데이터 개수")
+    long totalElements,
+
+    @Schema(description = "다음 페이지 존재 여부")
+    boolean hasNext
+) {
+}

--- a/src/main/java/com/codeit/monew/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/codeit/monew/domain/comment/repository/CommentLikeRepository.java
@@ -1,6 +1,7 @@
 package com.codeit.monew.domain.comment.repository;
 
 import com.codeit.monew.domain.comment.entity.CommentLike;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,4 +22,8 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
   @Modifying
   @Query("DELETE FROM CommentLike cl WHERE cl.comment.id = :commentId")
   void deleteByCommentId(@Param("commentId") UUID commentId);
+
+  // 댓글 목록 조회 시 특정 유저가 좋아요를 누른 댓글 ID들만 한 번에 추출
+  @Query("SELECT cl.comment.id FROM CommentLike cl WHERE cl.user.id = :userId AND cl.comment.id IN :commentIds")
+  List<UUID> findLikedCommentIdsByUserAndComments(@Param("userId") UUID userId, @Param("commentIds") List<UUID> commentIds);
 }

--- a/src/main/java/com/codeit/monew/domain/comment/repository/CommentQueryRepository.java
+++ b/src/main/java/com/codeit/monew/domain/comment/repository/CommentQueryRepository.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.domain.comment.repository;
+
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
+import com.codeit.monew.domain.comment.entity.Comment;
+import java.util.List;
+import java.util.UUID;
+
+public interface CommentQueryRepository {
+
+  // 동적 정렬 및 커서 페이징을 적용한 댓글 목록 조회
+  List<Comment> findCommentsByCursor(UUID articleId, CommentCursorRequest request);
+}

--- a/src/main/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImpl.java
@@ -22,13 +22,24 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
 
   @Override
   public List<Comment> findCommentsByCursor(UUID articleId, CommentCursorRequest request) {
+
+    // 메인 커서 기준값과 UUID 문자열 분리
+    String realCursor = request.cursor(); // 메인 커서 값
+    UUID cursorId = null;                 // 고유 ID 커서 값
+
+    if (request.cursor() != null && request.cursor().contains("_")) {
+      String[] parts = request.cursor().split("_");
+      realCursor = parts[0];
+      cursorId = UUID.fromString(parts[1]); // 문자열을 다시 UUID 객체로 복원
+    }
+
     return queryFactory
         .selectFrom(comment)
         .leftJoin(comment.user).fetchJoin() // 사용자(닉네임) 정보를 한 번의 쿼리로 다 끌고 옴 (N+1 방어)
         .where(
             comment.article.id.eq(articleId), // 해당 기사의 댓글만 필터링
             comment.deletedAt.isNull(), // 논리 삭제된 댓글 제외
-            cursorCondition(request.orderBy(), request.direction(), request.cursor(), request.after())
+            cursorCondition(request.orderBy(), request.direction(), realCursor, request.after(), cursorId)
         )
         .orderBy(createOrderSpecifier(request.orderBy(), request.direction()))
         .limit(request.limit() + 1) // hasNext 판별을 위해 요청한 개수보다 1개 더 가져옴
@@ -36,7 +47,7 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
   }
 
   // 동적 커서 조건 생성기
-  private BooleanExpression cursorCondition(String orderBy, String direction, String cursor, Instant after) {
+  private BooleanExpression cursorCondition(String orderBy, String direction, String cursor, Instant after, UUID cursorId) {
     // 커서가 없다면 첫 페이지 요청이므로 조건 없이 진행
     if (cursor == null && after == null) {
       return null;
@@ -44,30 +55,34 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
 
     // 1. 좋아요순 정렬일 때
     if ("likeCount".equals(orderBy)) {
-      if (cursor == null || after == null) return null; // 파라미터 누락 방어
+      if (cursor == null || after == null || cursorId == null) return null; // 파라미터 누락 방어
 
       long cursorLikeCount = Long.parseLong(cursor); // 메인 커서
 
       if ("DESC".equalsIgnoreCase(direction)) { // [내림차순]
         return comment.likeCount.lt(cursorLikeCount) // 좋아요 수가 이전 댓글보다 적거나
             .or(comment.likeCount.eq(cursorLikeCount) // 좋아요 수는 같은데
-                    .and(comment.createdAt.lt(after)) // 작성일이 더 예전(lt)인 것
+                .and(comment.createdAt.lt(after)) // 작성일이 더 예전(lt)인 것
+                .or(comment.createdAt.eq(after).and(comment.id.lt(cursorId))) // 고유 ID로 최종 동점자 판별
             );
       } else { // [오름차순]
         return comment.likeCount.gt(cursorLikeCount) // 좋아요 수가 이전 댓글보다 많거나
             .or(comment.likeCount.eq(cursorLikeCount) // 좋아요 수는 같은데
-                    .and(comment.createdAt.gt(after)) // 작성일이 더 최신(gt)인 것
+                .and(comment.createdAt.gt(after)) // 작성일이 더 최신(gt)인 것
+                .or(comment.createdAt.eq(after).and(comment.id.gt(cursorId))) // 고유 ID로 최종 동점자 판별
             );
       }
     }
 
     // 2. 작성일자순 정렬일 때
-    if (after == null) return null; // 파라미터 누락 방어
+    if (after == null || cursorId == null) return null; // 파라미터 누락 방어
 
     if ("DESC".equalsIgnoreCase(direction)) { // [내림차순]
-      return comment.createdAt.lt(after); // 이전 페이지의 마지막 댓글 작성일자보다 더 과거(lt)인 댓글들만 가져옴
+      return comment.createdAt.lt(after) // 이전 페이지의 마지막 댓글 작성일자보다 더 과거(lt)인 댓글들만 가져옴
+          .or(comment.createdAt.eq(after).and(comment.id.lt(cursorId))); // 고유 ID로 최종 동점자 판별
     } else { // [오름차순]
-      return comment.createdAt.gt(after); // 이전 페이지의 마지막 댓글 작성일자보다 더 최신(gt)인 댓글들만 가져옴
+      return comment.createdAt.gt(after) // 이전 페이지의 마지막 댓글 작성일자보다 더 최신(gt)인 댓글들만 가져옴
+          .or(comment.createdAt.eq(after).and(comment.id.gt(cursorId))); // 고유 ID로 최종 동점자 판별
     }
   }
 
@@ -76,16 +91,18 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
     Order directionOrder = "ASC".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC;
 
     if ("likeCount".equals(orderBy)) {
-      // 좋아요 정렬 시, 동점일 경우 작성일자 기준으로 한 번 더 정렬
+      // 좋아요 정렬 시
       return new OrderSpecifier[]{
           new OrderSpecifier<>(directionOrder, comment.likeCount), // 1순위: 좋아요 수
-          new OrderSpecifier<>(directionOrder, comment.createdAt) // 2순위: 작성일자
+          new OrderSpecifier<>(directionOrder, comment.createdAt), // 2순위: 작성일자
+          new OrderSpecifier<>(directionOrder, comment.id) // 3순위: 고유 ID
       };
     }
 
-    // 최신순 정렬일 때는 조건 하나만 있으면 됨
+    // 최신순 정렬 시
     return new OrderSpecifier[]{
-        new OrderSpecifier<>(directionOrder, comment.createdAt)
+        new OrderSpecifier<>(directionOrder, comment.createdAt), // 1순위: 작성일자
+        new OrderSpecifier<>(directionOrder, comment.id) // 2순위: 고유 ID
     };
   }
 }

--- a/src/main/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImpl.java
@@ -1,0 +1,91 @@
+package com.codeit.monew.domain.comment.repository.impl;
+
+import static com.codeit.monew.domain.comment.entity.QComment.comment;
+
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.comment.repository.CommentQueryRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQueryRepositoryImpl implements CommentQueryRepository {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Comment> findCommentsByCursor(UUID articleId, CommentCursorRequest request) {
+    return queryFactory
+        .selectFrom(comment)
+        .leftJoin(comment.user).fetchJoin() // 사용자(닉네임) 정보를 한 번의 쿼리로 다 끌고 옴 (N+1 방어)
+        .where(
+            comment.article.id.eq(articleId), // 해당 기사의 댓글만 필터링
+            comment.deletedAt.isNull(), // 논리 삭제된 댓글 제외
+            cursorCondition(request.orderBy(), request.direction(), request.cursor(), request.after())
+        )
+        .orderBy(createOrderSpecifier(request.orderBy(), request.direction()))
+        .limit(request.limit() + 1) // hasNext 판별을 위해 요청한 개수보다 1개 더 가져옴
+        .fetch();
+  }
+
+  // 동적 커서 조건 생성기
+  private BooleanExpression cursorCondition(String orderBy, String direction, String cursor, Instant after) {
+    // 커서가 없다면 첫 페이지 요청이므로 조건 없이 진행
+    if (cursor == null && after == null) {
+      return null;
+    }
+
+    // 1. 좋아요순 정렬일 때
+    if ("likeCount".equals(orderBy)) {
+      if (cursor == null || after == null) return null; // 파라미터 누락 방어
+
+      long cursorLikeCount = Long.parseLong(cursor); // 메인 커서
+
+      if ("DESC".equalsIgnoreCase(direction)) { // [내림차순]
+        return comment.likeCount.lt(cursorLikeCount) // 좋아요 수가 이전 댓글보다 적거나
+            .or(comment.likeCount.eq(cursorLikeCount) // 좋아요 수는 같은데
+                    .and(comment.createdAt.lt(after)) // 작성일이 더 예전(lt)인 것
+            );
+      } else { // [오름차순]
+        return comment.likeCount.gt(cursorLikeCount) // 좋아요 수가 이전 댓글보다 많거나
+            .or(comment.likeCount.eq(cursorLikeCount) // 좋아요 수는 같은데
+                    .and(comment.createdAt.gt(after)) // 작성일이 더 최신(gt)인 것
+            );
+      }
+    }
+
+    // 2. 작성일자순 정렬일 때
+    if (after == null) return null; // 파라미터 누락 방어
+
+    if ("DESC".equalsIgnoreCase(direction)) { // [내림차순]
+      return comment.createdAt.lt(after); // 이전 페이지의 마지막 댓글 작성일자보다 더 과거(lt)인 댓글들만 가져옴
+    } else { // [오름차순]
+      return comment.createdAt.gt(after); // 이전 페이지의 마지막 댓글 작성일자보다 더 최신(gt)인 댓글들만 가져옴
+    }
+  }
+
+  // 동적 정렬 조건 생성기
+  private OrderSpecifier<?>[] createOrderSpecifier(String orderBy, String direction) {
+    Order directionOrder = "ASC".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC;
+
+    if ("likeCount".equals(orderBy)) {
+      // 좋아요 정렬 시, 동점일 경우 작성일자 기준으로 한 번 더 정렬
+      return new OrderSpecifier[]{
+          new OrderSpecifier<>(directionOrder, comment.likeCount), // 1순위: 좋아요 수
+          new OrderSpecifier<>(directionOrder, comment.createdAt) // 2순위: 작성일자
+      };
+    }
+
+    // 최신순 정렬일 때는 조건 하나만 있으면 됨
+    return new OrderSpecifier[]{
+        new OrderSpecifier<>(directionOrder, comment.createdAt)
+    };
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
@@ -159,9 +159,9 @@ public class CommentService {
       nextAfter = lastComment.getCreatedAt(); // 보조 커서는 작성일자
 
       if ("likeCount".equals(request.orderBy())) {
-        nextCursor = String.valueOf(lastComment.getLikeCount());
+        nextCursor = lastComment.getLikeCount() + "_" + lastComment.getId(); // nextCursor 필드 기준값에 UUID를 추가하여 중복 방지
       } else {
-        nextCursor = lastComment.getCreatedAt().toString();
+        nextCursor = lastComment.getCreatedAt().toString() + "_" + lastComment.getId();
       }
     }
 

--- a/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/monew/domain/comment/service/CommentService.java
@@ -2,16 +2,23 @@ package com.codeit.monew.domain.comment.service;
 
 import com.codeit.monew.domain.article.entity.Article;
 import com.codeit.monew.domain.article.repository.ArticleRepository;
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
 import com.codeit.monew.domain.comment.dto.CommentDto;
+import com.codeit.monew.domain.comment.dto.CursorPageResponseCommentDto;
 import com.codeit.monew.domain.comment.entity.Comment;
 import com.codeit.monew.domain.comment.mapper.CommentMapper;
 import com.codeit.monew.domain.comment.repository.CommentLikeRepository;
+import com.codeit.monew.domain.comment.repository.CommentQueryRepository;
 import com.codeit.monew.domain.comment.repository.CommentRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.comment.CommentNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,11 +36,13 @@ public class CommentService {
   private final CommentLikeRepository commentLikeRepository;
   private final ArticleRepository articleRepository;
   private final UserRepository userRepository;
+  private final CommentQueryRepository commentQueryRepository;
   private final CommentMapper commentMapper;
 
   // 댓글 등록
   @Transactional
   public CommentDto registerComment(UUID articleId, UUID userId, String content) {
+    log.debug("[COMMENT_CREATE] 댓글 등록 요청: articleId={}, userId={}", articleId, userId);
 
     // 1. 유저 조회 및 검증
     User user = userRepository.findByIdAndDeletedAtIsNull(userId)
@@ -46,7 +55,7 @@ public class CommentService {
     // 3. 댓글 엔티티 생성 및 영속화
     Comment comment = new Comment(article, user, content);
     Comment savedComment = commentRepository.save(comment);
-    log.info("댓글 등록 완료: commentId= {}, articleId= {}", savedComment.getId(), articleId);
+    log.info("[COMMENT_POST] 댓글 등록 완료: commentId= {}, articleId= {}", savedComment.getId(), articleId);
 
     // 4. DTO로 변환
     boolean likedByMe = false; // 댓글 등록 시점에는 좋아요가 없으므로 false로 초기화
@@ -56,13 +65,15 @@ public class CommentService {
   // 댓글 수정
   @Transactional
   public CommentDto updateComment(UUID commentId, UUID requesterId, String content) {
+    log.debug("[COMMENT_UPDATE] 댓글 수정 요청: commentId={}, requesterId={}", commentId, requesterId);
+
     // 1. 댓글 및 작성자 정보 한 번에 조회
     Comment comment = commentRepository.findByIdWithUser(commentId)
         .orElseThrow(() -> new CommentNotFoundException(commentId));
 
     // 2. 엔티티 내부에서 권한 검증 및 수정 수행
     comment.updateContent(content, requesterId);
-    log.info("댓글 수정 완료: commentId= {}, requesterId= {}", commentId, requesterId);
+    log.info("[COMMENT_UPDATE] 댓글 수정 완료: commentId= {}, requesterId= {}", commentId, requesterId);
 
     // 3. DTO 변환
     boolean likedByMe = commentLikeRepository.existsByCommentIdAndUserId(commentId, requesterId);
@@ -72,17 +83,21 @@ public class CommentService {
   // 댓글 논리 삭제 (삭제 기본값)
   @Transactional
   public void deleteComment(UUID commentId) {
+    log.debug("[COMMENT_DELETE] 댓글 논리 삭제 요청: commentId={}", commentId);
+
     Comment comment = commentRepository.findById(commentId)
         .orElseThrow(() -> new CommentNotFoundException(commentId));
 
     // 엔티티에 설정된 @SQLDelete 작동 -> deleted_at에 현재 시간 기록
     commentRepository.delete(comment);
-    log.info("댓글 논리 삭제 완료: commentId= {}", commentId);
+    log.info("[COMMENT_DELETE] 댓글 논리 삭제 완료: commentId= {}", commentId);
   }
 
   // 댓글 물리 삭제
   @Transactional
   public void hardDeleteComment(UUID commentId) {
+    log.debug("[COMMENT_DELETE] 댓글 물리 삭제 요청: commentId={}", commentId);
+
     // 1. 댓글 존재 여부 확인
     boolean exists = commentRepository.existsById(commentId);
     if (!exists) {
@@ -94,6 +109,76 @@ public class CommentService {
 
     // 3. 댓글 물리 삭제
     commentRepository.deleteByIdHard(commentId);
-    log.info("댓글 물리 삭제 완료: commentId= {}", commentId);
+    log.info("[COMMENT_DELETE] 댓글 물리 삭제 완료: commentId= {}", commentId);
+  }
+
+  // 댓글 목록 조회
+  @Transactional(readOnly = true)
+  public CursorPageResponseCommentDto getCommentList(UUID articleId, UUID requesterId, CommentCursorRequest request) {
+
+    log.debug("[COMMENT_READ] 댓글 목록 조회 요청: articleId={}, requesterId={}, orderBy={}, cursor={}",
+        articleId, requesterId, request.orderBy(), request.cursor());
+
+    // 1. 기사 존재 여부 검증
+    if (!articleRepository.existsById(articleId)) {
+      throw new ArticleNotFoundException(articleId);
+    }
+
+    // 2. 커서 기반으로 댓글 엔티티 목록 조회
+    List<Comment> comments = commentQueryRepository.findCommentsByCursor(articleId, request);
+
+    // 3. 다음 페이지 존재 여부(hasNext) 판별 및 초과 데이터 자르기
+    boolean hasNext = comments.size() > request.limit();
+    if (hasNext) {
+      comments.remove(comments.size() - 1);
+    }
+
+    // 4. 조회된 댓글 ID 추출 및 좋아요 여부 한 번에 가져오기
+    Set<UUID> likedCommentIds = new HashSet<>();
+    if (!comments.isEmpty()) {
+      List<UUID> commentIds = comments.stream().map(Comment::getId).toList();
+
+      // 해당 유저가 좋아요를 누른 댓글 ID만 한 번에 가져와서 Set(O(1) 조회 속도)에 담기
+      List<UUID> likedList = commentLikeRepository.findLikedCommentIdsByUserAndComments(requesterId, commentIds);
+      likedCommentIds.addAll(likedList);
+    }
+
+    // 5. DTO 변환
+    List<CommentDto> content = comments.stream()
+        .map(comment -> {
+          boolean likedByMe = likedCommentIds.contains(comment.getId()); // Set에서 조회하므로 빠르게 매핑 가능
+          return commentMapper.toDto(comment, comment.getUser().getNickname(), likedByMe);
+        }).toList();
+
+    // 6. 다음 페이지를 위한 커서 계산
+    String nextCursor = null;
+    Instant nextAfter = null;
+
+    if (hasNext && !comments.isEmpty()) {
+      Comment lastComment = comments.get(comments.size() - 1);
+      nextAfter = lastComment.getCreatedAt(); // 보조 커서는 작성일자
+
+      if ("likeCount".equals(request.orderBy())) {
+        nextCursor = String.valueOf(lastComment.getLikeCount());
+      } else {
+        nextCursor = lastComment.getCreatedAt().toString();
+      }
+    }
+
+    // 7. 전체 요소 개수 조회
+    long totalElements = commentRepository.countByArticleIdAndDeletedAtIsNull(articleId);
+
+    log.info("[COMMENT_READ] 댓글 목록 조회 완료: articleId={}, 응답 데이터 수={}, hasNext={}",
+        articleId, content.size(), hasNext);
+
+    // 8. 최종 응답 DTO 생성
+    return new CursorPageResponseCommentDto(
+        content,
+        nextCursor,
+        nextAfter,
+        content.size(),
+        totalElements,
+        hasNext
+    );
   }
 }

--- a/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/controller/CommentControllerTest.java
@@ -1,13 +1,16 @@
 package com.codeit.monew.domain.comment.controller;
 
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
 import com.codeit.monew.domain.comment.dto.CommentDto;
 import com.codeit.monew.domain.comment.dto.CommentRegisterRequest;
 import com.codeit.monew.domain.comment.dto.CommentUpdateRequest;
+import com.codeit.monew.domain.comment.dto.CursorPageResponseCommentDto;
 import com.codeit.monew.domain.comment.service.CommentService;
 import com.codeit.monew.global.exception.comment.CommentNotFoundException;
 import com.codeit.monew.global.exception.comment.CommentUpdateForbiddenException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,8 +27,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -271,6 +276,94 @@ class CommentControllerTest {
           .andDo(print())
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("COMMENT_NOT_FOUND"));
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 목록 조회 API 테스트")
+  class GetCommentListApiTest {
+
+    @Test
+    @DisplayName("올바른 파라미터로 요청하면 200 OK와 함께 페이징 데이터를 반환한다.")
+    void success_getCommentList() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID requesterId = UUID.randomUUID();
+      Instant now = Instant.now();
+
+      CommentDto mockComment = new CommentDto(
+          UUID.randomUUID(), articleId, UUID.randomUUID(), "테스트 닉네임",
+          "테스트 댓글", 10L, true, now
+      );
+
+      CursorPageResponseCommentDto responseDto = new CursorPageResponseCommentDto(
+          List.of(mockComment), "10", now, 1, 15L, true
+      );
+
+      given(commentService.getCommentList(eq(articleId), eq(requesterId), any(CommentCursorRequest.class)))
+          .willReturn(responseDto);
+
+      // when & then
+      mockMvc.perform(get("/api/comments")
+              .header("Monew-Request-User-ID", requesterId.toString())
+              .param("articleId", articleId.toString())
+              .param("orderBy", "likeCount")
+              .param("direction", "DESC")
+              .param("limit", "10"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[0].content").value("테스트 댓글"))
+          .andExpect(jsonPath("$.nextCursor").value("10"))
+          .andExpect(jsonPath("$.hasNext").value(true))
+          .andExpect(jsonPath("$.totalElements").value(15));
+    }
+
+    @Test
+    @DisplayName("limit가 최대 허용치(100)를 초과하면 400 Bad Request를 반환한다.")
+    void fail_limit_exceeded() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID requesterId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(get("/api/comments")
+              .header("Monew-Request-User-ID", requesterId.toString())
+              .param("articleId", articleId.toString())
+              .param("limit", "101"))
+          .andExpect(status().isBadRequest());
+
+      verify(commentService, never()).getCommentList(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("올바르지 않은 정렬 기준(orderBy)이 들어오면 400 Bad Request를 반환한다.")
+    void fail_invalid_orderBy() throws Exception {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID requesterId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(get("/api/comments")
+              .header("Monew-Request-User-ID", requesterId.toString())
+              .param("articleId", articleId.toString())
+              .param("orderBy", "weirdCondition"))
+          .andExpect(status().isBadRequest());
+
+      verify(commentService, never()).getCommentList(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("필수 파라미터인 articleId가 누락되면 400 Bad Request를 반환한다.")
+    void fail_missing_articleId() throws Exception {
+      // given
+      UUID requesterId = UUID.randomUUID();
+
+      // when & then
+      mockMvc.perform(get("/api/comments")
+              .header("Monew-Request-User-ID", requesterId.toString())
+              .param("limit", "10"))
+          .andExpect(status().isBadRequest());
+
+      verify(commentService, never()).getCommentList(any(), any(), any());
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/comment/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/repository/CommentLikeRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.codeit.monew.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.monew.domain.article.ArticleSource;
+import com.codeit.monew.domain.article.entity.Article;
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.comment.entity.CommentLike;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.global.config.JpaAuditingConfig;
+import com.codeit.monew.global.config.QueryDslConfig;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class CommentLikeRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private CommentLikeRepository commentLikeRepository;
+
+  private User testUser;
+  private Article testArticle;
+  private Comment testComment1;
+  private Comment testComment2;
+
+  @BeforeEach
+  void setUp() {
+    testUser = new User("test@test.com", "테스터", "password");
+    em.persist(testUser);
+
+    testArticle = Article.createArticle(ArticleSource.NAVER, "https://naver.com/2", "테스트 기사2", Instant.now(), "요약");
+    em.persist(testArticle);
+
+    testComment1 = new Comment(testArticle, testUser, "첫 번째 댓글");
+    testComment2 = new Comment(testArticle, testUser, "두 번째 댓글");
+    em.persist(testComment1);
+    em.persist(testComment2);
+
+    CommentLike commentLike = new CommentLike(testComment1, testUser);
+    em.persist(commentLike);
+
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("existsByCommentIdAndUserId: 좋아요 존재 여부를 정확히 반환한다.")
+  void existsByCommentIdAndUserId() {
+    // when
+    boolean exists1 = commentLikeRepository.existsByCommentIdAndUserId(testComment1.getId(), testUser.getId());
+    boolean exists2 = commentLikeRepository.existsByCommentIdAndUserId(testComment2.getId(), testUser.getId());
+
+    // then
+    assertThat(exists1).isTrue();
+    assertThat(exists2).isFalse();
+  }
+
+  @Test
+  @DisplayName("deleteByCommentIdAndUserId: 특정 유저의 특정 댓글 좋아요만 삭제하고 1을 반환한다.")
+  void deleteByCommentIdAndUserId() {
+    // when
+    int deletedCount = commentLikeRepository.deleteByCommentIdAndUserId(testComment1.getId(), testUser.getId());
+    em.clear();
+
+    // then
+    assertThat(deletedCount).isEqualTo(1);
+    boolean exists = commentLikeRepository.existsByCommentIdAndUserId(testComment1.getId(), testUser.getId());
+    assertThat(exists).isFalse();
+  }
+
+  @Test
+  @DisplayName("deleteByCommentId: 댓글 물리 삭제 시 해당 댓글에 달린 모든 좋아요가 삭제된다.")
+  void deleteByCommentId() {
+    // given
+    User anotherUser = new User("other@test.com", "다른유저", "password");
+    em.persist(anotherUser);
+    CommentLike anotherLike = new CommentLike(testComment1, anotherUser);
+    em.persist(anotherLike);
+    em.flush();
+    em.clear();
+
+    // when
+    commentLikeRepository.deleteByCommentId(testComment1.getId());
+    em.clear();
+
+    // then
+    assertThat(commentLikeRepository.existsByCommentIdAndUserId(testComment1.getId(), testUser.getId())).isFalse();
+    assertThat(commentLikeRepository.existsByCommentIdAndUserId(testComment1.getId(), anotherUser.getId())).isFalse();
+  }
+
+  @Test
+  @DisplayName("findLikedCommentIdsByUserAndComments: N+1 방어 IN 쿼리가 정확히 동작한다.")
+  void findLikedCommentIdsByUserAndComments() {
+    // given
+    List<java.util.UUID> searchIds = List.of(testComment1.getId(), testComment2.getId());
+
+    // when
+    List<java.util.UUID> likedIds = commentLikeRepository.findLikedCommentIdsByUserAndComments(testUser.getId(), searchIds);
+
+    // then
+    assertThat(likedIds).hasSize(1);
+    assertThat(likedIds).containsExactly(testComment1.getId());
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.codeit.monew.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.monew.domain.article.ArticleSource;
+import com.codeit.monew.domain.article.entity.Article;
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.global.config.JpaAuditingConfig;
+import com.codeit.monew.global.config.QueryDslConfig;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class CommentRepositoryTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private CommentRepository commentRepository;
+
+  private User testUser;
+  private Article testArticle;
+  private Comment testComment;
+
+  @BeforeEach
+  void setUp() {
+    testUser = new User("test@test.com", "테스터", "password");
+    em.persist(testUser);
+
+    testArticle = Article.createArticle(ArticleSource.NAVER, "https://naver.com/1", "테스트 기사", Instant.now(), "요약");
+    em.persist(testArticle);
+
+    testComment = new Comment(testArticle, testUser, "테스트 댓글입니다.");
+    em.persist(testComment);
+
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("countByArticleIdAndDeletedAtIsNull: 삭제되지 않은 기사의 댓글 개수를 정확히 샌다.")
+  void countByArticleIdAndDeletedAtIsNull() {
+    // given
+    Comment deletedComment = new Comment(testArticle, testUser, "삭제될 댓글");
+    em.persist(deletedComment);
+
+    commentRepository.delete(deletedComment);
+    em.flush();
+    em.clear();
+
+    // when
+    long count = commentRepository.countByArticleIdAndDeletedAtIsNull(testArticle.getId());
+
+    // then
+    assertThat(count).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("findByIdWithUser: fetch join을 통해 댓글과 유저 정보를 한 번에 가져온다.")
+  void findByIdWithUser() {
+    // when
+    Optional<Comment> foundComment = commentRepository.findByIdWithUser(testComment.getId());
+
+    // then
+    assertThat(foundComment).isPresent();
+    assertThat(foundComment.get().getUser().getNickname()).isEqualTo("테스터");
+  }
+
+  @Test
+  @DisplayName("deleteByIdHard: @Modifying 쿼리가 실행되어 DB에서 댓글이 완전히 삭제된다.")
+  void deleteByIdHard() {
+    // when
+    commentRepository.deleteByIdHard(testComment.getId());
+    em.clear();
+
+    // then
+    Optional<Comment> deletedComment = commentRepository.findById(testComment.getId());
+    assertThat(deletedComment).isEmpty();
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImplTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImplTest.java
@@ -90,8 +90,11 @@ class CommentQueryRepositoryImplTest {
     @DisplayName("createdAt 커서 조회 시, 이전 페이지의 마지막 작성일자 이후의 데이터를 조회한다.")
     void findCommentsByCursor_createdAt_desc() {
       // given
-      Instant cursorAfter = comments.get(3).getCreatedAt(); // "댓글 4"의 정확한 DB 작성 시간
-      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "DESC", null, cursorAfter, 2);
+      Comment lastComment = comments.get(3); // 댓글 4
+      Instant cursorAfter = lastComment.getCreatedAt();
+      String compositeCursor = cursorAfter.toString() + "_" + lastComment.getId();
+
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "DESC", compositeCursor, cursorAfter, 2);
 
       // when
       List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
@@ -106,9 +109,11 @@ class CommentQueryRepositoryImplTest {
     @DisplayName("likeCount 복합 커서 조회 시, 좋아요 수가 같을 때 작성일자로 동점자를 가려낸다.")
     void findCommentsByCursor_likeCount_desc_tieBreaker() {
       // given
-      String cursorLikeCount = "10";
-      Instant cursorAfter = comments.get(1).getCreatedAt(); // "댓글 2"의 정확한 DB 작성 시간
-      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "DESC", cursorLikeCount, cursorAfter, 3);
+      Comment lastComment = comments.get(1); // 댓글 2
+      Instant cursorAfter = lastComment.getCreatedAt();
+      String compositeCursor = lastComment.getLikeCount() + "_" + lastComment.getId();
+
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "DESC", compositeCursor, cursorAfter, 3);
 
       // when
       List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
@@ -124,10 +129,12 @@ class CommentQueryRepositoryImplTest {
     @Test
     @DisplayName("좋아요순 조건문의 반대 분기(오름차순(ASC))도 정상 동작한다.")
     void findCommentsByCursor_likeCount_asc() {
-      // given: 오름차순(ASC)으로 커서 요청 (3번 댓글 커서 기준)
-      String cursorLikeCount = "5";
-      Instant cursorAfter = comments.get(2).getCreatedAt();
-      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "ASC", cursorLikeCount, cursorAfter, 2);
+      // given
+      Comment lastComment = comments.get(2); // "댓글 3" (좋아요 5)
+      Instant cursorAfter = lastComment.getCreatedAt();
+      String compositeCursor = lastComment.getLikeCount() + "_" + lastComment.getId();
+
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "ASC", compositeCursor, cursorAfter, 2);
 
       // when
       List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
@@ -141,9 +148,12 @@ class CommentQueryRepositoryImplTest {
     @Test
     @DisplayName("createdAt순 조건문의 반대 분기(오름차순(ASC))도 정상 동작한다.")
     void findCommentsByCursor_createdAt_asc() {
-      // given: 오름차순(ASC)으로 커서 요청 (3번 댓글 커서 기준)
-      Instant cursorAfter = comments.get(2).getCreatedAt();
-      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "ASC", null, cursorAfter, 2);
+      // given
+      Comment lastComment = comments.get(2); // 댓글 3
+      Instant cursorAfter = lastComment.getCreatedAt();
+      String compositeCursor = cursorAfter.toString() + "_" + lastComment.getId();
+
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "ASC", compositeCursor, cursorAfter, 2);
 
       // when
       List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);

--- a/src/test/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImplTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/repository/impl/CommentQueryRepositoryImplTest.java
@@ -1,0 +1,183 @@
+package com.codeit.monew.domain.comment.repository.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.monew.domain.article.ArticleSource;
+import com.codeit.monew.domain.article.entity.Article;
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.comment.repository.CommentQueryRepository;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.global.config.JpaAuditingConfig;
+import com.codeit.monew.global.config.QueryDslConfig;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class, CommentQueryRepositoryImpl.class})
+class CommentQueryRepositoryImplTest {
+
+  @Autowired private TestEntityManager em;
+  @Autowired private CommentQueryRepository commentQueryRepository;
+
+  private User testUser;
+  private Article testArticle;
+  private List<Comment> comments = new ArrayList<>();
+
+  @BeforeEach
+  void setUp() throws InterruptedException {
+    testUser = new User("test@test.com", "테스트 닉네임", "password1234!");
+    em.persist(testUser);
+
+    testArticle = Article.createArticle(ArticleSource.NAVER, "https://naver.com/3", "테스트 기사3", Instant.now(), "요약");
+    em.persist(testArticle);
+
+    // 댓글 5개 세팅
+    for (int i = 1; i <= 5; i++) {
+      Comment comment = new Comment(testArticle, testUser, "댓글 " + i);
+
+      // 좋아요 수 세팅 - 1번: 10개, 2번: 10개(동점), 3번: 5개, 4번: 2개, 5번: 0개
+      long likes = (i <= 2) ? 10L : (i == 3) ? 5L : (i == 4) ? 2L : 0L;
+      ReflectionTestUtils.setField(comment, "likeCount", likes);
+
+      em.persist(comment);
+      Thread.sleep(10); // JpaAuditing의 createdAt이 확실하게 구분되도록 미세한 딜레이 부여
+    }
+
+    em.flush();
+    em.clear();
+
+    comments = em.getEntityManager()
+        .createQuery("SELECT c FROM Comment c ORDER BY c.createdAt ASC", Comment.class)
+        .getResultList();
+  }
+
+  @Nested
+  @DisplayName("댓글 목록 조회 Query Repository 테스트")
+  class read_comment {
+
+    @Test
+    @DisplayName("최초 조회 (cursor 없음) 시, 정해진 limit + 1개만큼 올바르게 조회된다.")
+    void findCommentsByCursor_firstPage() {
+      // given
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "DESC", null, null, 3);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      assertThat(result).hasSize(4);
+      // 최신순이므로 5번 댓글이 제일 먼저 나와야 함
+      assertThat(result.get(0).getContent()).isEqualTo("댓글 5");
+      assertThat(result.get(1).getContent()).isEqualTo("댓글 4");
+    }
+
+    @Test
+    @DisplayName("createdAt 커서 조회 시, 이전 페이지의 마지막 작성일자 이후의 데이터를 조회한다.")
+    void findCommentsByCursor_createdAt_desc() {
+      // given
+      Instant cursorAfter = comments.get(3).getCreatedAt(); // "댓글 4"의 정확한 DB 작성 시간
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "DESC", null, cursorAfter, 2);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      assertThat(result).isNotEmpty();
+      // 최신순(내림차순)에서 4번 댓글 다음은 더 과거에 작성된 3번 댓글이어야 함
+      assertThat(result.get(0).getContent()).isEqualTo("댓글 3");
+    }
+
+    @Test
+    @DisplayName("likeCount 복합 커서 조회 시, 좋아요 수가 같을 때 작성일자로 동점자를 가려낸다.")
+    void findCommentsByCursor_likeCount_desc_tieBreaker() {
+      // given
+      String cursorLikeCount = "10";
+      Instant cursorAfter = comments.get(1).getCreatedAt(); // "댓글 2"의 정확한 DB 작성 시간
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "DESC", cursorLikeCount, cursorAfter, 3);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      // 2번 댓글(좋아요 10)의 다음 순위는
+      // 1. 좋아요가 같으면서 더 과거에 쓴 1번 댓글 (좋아요 10)
+      // 2. 그 다음으로 좋아요가 많은 3번 댓글 (좋아요 5)
+      assertThat(result.get(0).getContent()).isEqualTo("댓글 1");
+      assertThat(result.get(1).getContent()).isEqualTo("댓글 3");
+    }
+
+    @Test
+    @DisplayName("좋아요순 조건문의 반대 분기(오름차순(ASC))도 정상 동작한다.")
+    void findCommentsByCursor_likeCount_asc() {
+      // given: 오름차순(ASC)으로 커서 요청 (3번 댓글 커서 기준)
+      String cursorLikeCount = "5";
+      Instant cursorAfter = comments.get(2).getCreatedAt();
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "ASC", cursorLikeCount, cursorAfter, 2);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      // 좋아요 오름차순이므로, 5개짜리 다음은 10개짜리들이 나와야 함
+      assertThat(result).isNotEmpty();
+      assertThat(result.get(0).getLikeCount()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("createdAt순 조건문의 반대 분기(오름차순(ASC))도 정상 동작한다.")
+    void findCommentsByCursor_createdAt_asc() {
+      // given: 오름차순(ASC)으로 커서 요청 (3번 댓글 커서 기준)
+      Instant cursorAfter = comments.get(2).getCreatedAt();
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "ASC", null, cursorAfter, 2);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      assertThat(result).isNotEmpty();
+      // 가장 오래된 것부터 오름차순이므로, 3번 다음은 더 최근에 쓰여진 4번 댓글이 나와야 함
+      assertThat(result.get(0).getContent()).isEqualTo("댓글 4");
+    }
+
+    @Test
+    @DisplayName("likeCount 정렬 시 커서 파라미터가 누락되면 조건 없이 무시된다.")
+    void findCommentsByCursor_likeCount_missing_parameters() {
+      // given
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "likeCount", "DESC", null, null, 2);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("createdAt 정렬 시 after 파라미터가 누락되면 조건 없이 무시된다.")
+    void findCommentsByCursor_createdAt_missing_parameters() {
+      // given
+      CommentCursorRequest request = new CommentCursorRequest(testArticle.getId(), "createdAt", "DESC", "someCursor", null, 2);
+
+      // when
+      List<Comment> result = commentQueryRepository.findCommentsByCursor(testArticle.getId(), request);
+
+      // then
+      assertThat(result).hasSize(3);
+    }
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
@@ -2,16 +2,21 @@ package com.codeit.monew.domain.comment.service;
 
 import com.codeit.monew.domain.article.entity.Article;
 import com.codeit.monew.domain.article.repository.ArticleRepository;
+import com.codeit.monew.domain.comment.dto.CommentCursorRequest;
 import com.codeit.monew.domain.comment.dto.CommentDto;
+import com.codeit.monew.domain.comment.dto.CursorPageResponseCommentDto;
 import com.codeit.monew.domain.comment.entity.Comment;
 import com.codeit.monew.domain.comment.mapper.CommentMapper;
 import com.codeit.monew.domain.comment.repository.CommentLikeRepository;
+import com.codeit.monew.domain.comment.repository.CommentQueryRepository;
 import com.codeit.monew.domain.comment.repository.CommentRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,12 +28,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -43,6 +51,7 @@ class CommentServiceTest {
   @Mock private CommentLikeRepository commentLikeRepository;
   @Mock private ArticleRepository articleRepository;
   @Mock private UserRepository userRepository;
+  @Mock private CommentQueryRepository commentQueryRepository;
   @Mock private CommentMapper commentMapper;
 
   @Nested
@@ -87,7 +96,7 @@ class CommentServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 유저 ID가 들어오면 UserNotFoundException이 발생한다.")
-    void fail_comment_userNotFound() {
+    void fail_comment_UserNotFound() {
       // given
       UUID articleId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
@@ -106,7 +115,7 @@ class CommentServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 기사 ID가 들어오면 ArticleNotFoundException이 발생한다.")
-    void fail_comment_articleNotFound() {
+    void fail_comment_ArticleNotFound() {
       // given
       UUID articleId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
@@ -165,7 +174,7 @@ class CommentServiceTest {
 
     @Test
     @DisplayName("DB에 존재하지 않는 댓글 ID로 요청하면 CommentNotFoundException이 발생한다.")
-    void fail_commentNotFound() {
+    void fail_comment_NotFound() {
       // given
       UUID commentId = UUID.randomUUID();
       UUID requesterId = UUID.randomUUID();
@@ -179,7 +188,7 @@ class CommentServiceTest {
 
     @Test
     @DisplayName("댓글 작성자가 아닌 다른 유저가 수정을 요청하면 CommentUpdateForbiddenException이 발생한다.")
-    void fail_commentUpdateForbidden() {
+    void fail_comment_UpdateForbidden() {
       // given
       UUID commentId = UUID.randomUUID();
       UUID authorId = UUID.randomUUID(); // 작성자
@@ -267,6 +276,73 @@ class CommentServiceTest {
           .isInstanceOf(com.codeit.monew.global.exception.comment.CommentNotFoundException.class);
 
       verify(commentRepository, never()).deleteByIdHard(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 목록 조회 테스트")
+  class ReadCommentList {
+
+    @Test
+    @DisplayName("요청한 limit보다 조회된 데이터가 많으면 hasNext=true를 반환하고 마지막 데이터를 자른다.")
+    void success_read_comment_hasNext_true() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID requesterId = UUID.randomUUID();
+      int limit = 2;
+      CommentCursorRequest request = new CommentCursorRequest(articleId, "createdAt", "DESC", null, null, limit);
+
+      given(articleRepository.existsById(articleId)).willReturn(true);
+
+      Article mockArticle = mock(Article.class);
+      User mockUser = mock(User.class);
+      given(mockUser.getNickname()).willReturn("테스트 닉네임");
+
+      List<Comment> mockComments = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        Comment comment = new Comment(mockArticle, mockUser, "테스트 내용 " + i);
+
+        ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(comment, "createdAt", Instant.now().minusSeconds(i));
+        ReflectionTestUtils.setField(comment, "likeCount", (long) i);
+
+        mockComments.add(comment);
+      }
+
+      given(commentQueryRepository.findCommentsByCursor(eq(articleId), any())).willReturn(mockComments);
+      given(commentLikeRepository.findLikedCommentIdsByUserAndComments(eq(requesterId), anyList()))
+          .willReturn(List.of(mockComments.get(0).getId()));
+      given(commentRepository.countByArticleIdAndDeletedAtIsNull(articleId)).willReturn(15L);
+
+      CommentDto mockDto = mock(CommentDto.class);
+      given(commentMapper.toDto(any(), anyString(), anyBoolean())).willReturn(mockDto);
+
+      // when
+      CursorPageResponseCommentDto response = commentService.getCommentList(articleId, requesterId, request);
+
+      // then
+      assertThat(response.hasNext()).isTrue();
+      assertThat(response.content()).hasSize(limit);
+      assertThat(response.totalElements()).isEqualTo(15L);
+
+      verify(commentLikeRepository).findLikedCommentIdsByUserAndComments(eq(requesterId), anyList()); // IN 쿼리가 1번 호출되었는지 검증
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기사 ID면 ArticleNotFoundException 발생한다.")
+    void fail_read_comment_ArticleNotFound() {
+      // given
+      UUID articleId = UUID.randomUUID();
+      UUID userId = UUID.randomUUID();
+      CommentCursorRequest request = new CommentCursorRequest(articleId, "createdAt", "DESC", null, null, 10);
+
+      given(articleRepository.existsById(articleId)).willReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> commentService.getCommentList(articleId, userId, request))
+          .isInstanceOf(ArticleNotFoundException.class);
+
+      verify(commentQueryRepository, never()).findCommentsByCursor(any(), any()); // 쿼리 레포지토리가 호출되지 않음을 검증
     }
   }
 }

--- a/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
@@ -325,6 +325,12 @@ class CommentServiceTest {
       assertThat(response.content()).hasSize(limit);
       assertThat(response.totalElements()).isEqualTo(15L);
 
+      Comment lastIncludedComment = mockComments.get(1);
+      String expectedCompositeCursor = lastIncludedComment.getCreatedAt().toString() + "_" + lastIncludedComment.getId();
+
+      assertThat(response.nextCursor()).isEqualTo(expectedCompositeCursor);
+      assertThat(response.nextAfter()).isEqualTo(lastIncludedComment.getCreatedAt());
+
       verify(commentLikeRepository).findLikedCommentIdsByUserAndComments(eq(requesterId), anyList()); // IN 쿼리가 1번 호출되었는지 검증
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #33

## 📝작업 내용

- 댓글 목록 조회 Controller 로직 구현
- 댓글 목록 조회 Service 로직 구현
- 댓글 목록 조회 요청 DTO 추가 (`CommentCursorRequest`)
- 댓글 목록 조회 Repository 로직 구현
- 댓글 목록 조회 계층별 테스트 코드 작성 (Controller, Service, Repository)

## 📸스크린샷 (선택)
- 해당사항 없음

## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글 목록 조회 API 추가 — 커서 기반 페이징으로 무한 스크롤 지원
  * 정렬 옵션 추가 — 생성일(createdAt) 또는 좋아요 수(likeCount) 기준, 오름/내림 선택 가능
  * 응답에 각 댓글의 사용자가 좋아요한 여부 포함

* **Tests**
  * 커서 페이징과 관련 저장소·서비스 동작을 검증하는 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->