### PR TITLE
[fix] 복합 커서로 뉴스 기사 목록 무한 스크롤 오류 및 일부 데이터 생략 문제 수정

### DIFF
--- a/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
+++ b/src/main/java/com/codeit/monew/domain/article/controller/ArticleController.java
@@ -99,12 +99,6 @@ public class ArticleController {
           publishDateTo);
     }
 
-    // cursor가 null이면 after도 null
-    if ((request.getCursor() == null) != (request.getAfter() == null)) {
-      throw new InvalidParameterException("cursor", request.getCursor(), "after",
-          request.getAfter());
-    }
-
     CursorPageResponseArticleDto response = articleService.search(request, requestUserId);
 
     return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
@@ -92,7 +92,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     Instant after = null;
     if (articleDtoSlice.hasNext() && lastArticleDto != null) {
       Instant createdAt = findCreatedAtById(article, lastArticleDto.id());
-      nextCursor = findNextCursor(lastArticleDto, request.getOrderBy(), createdAt);
+      nextCursor = findNextCursor(lastArticleDto, request.getOrderBy(), createdAt); // 복합 커서 조합
       after = createdAt;
     }
 
@@ -106,6 +106,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     );
   }
 
+  // 복합 커서용 내부 record(`publishDate`)
   private record PublishDateCursor(
       Instant publishDate,
       Instant createdAt,
@@ -114,6 +115,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
   }
 
+  // 복합 커서용 내부 record(`commentCount`, `viewCount`)
   private record CountCursor(
       Long count,
       Instant createdAt,
@@ -122,6 +124,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
   }
 
+  // `orderBy` 가 `publishDate` 일 때 복합 cursor 분리
   private PublishDateCursor parserPublishDateCursor(String cursor) {
     if (cursor == null) {
       return null;
@@ -143,6 +146,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     }
   }
 
+  // `orderBy` 가 `commentCount` 나 `viewCount` 일 때 복합 cursor 분리
   private CountCursor parserCountCursor(String cursor) {
     if (cursor == null) {
       return null;
@@ -164,6 +168,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     }
   }
 
+  // Instant 파싱
   private Instant parserInstant(String stringInstant) {
     if (stringInstant == null) {
       return null;
@@ -172,6 +177,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     return Instant.parse(stringInstant);
   }
 
+  // UUID 파싱
   private UUID parserUUID(String stringId) {
     if (stringId == null) {
       return null;
@@ -180,6 +186,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     return UUID.fromString(stringId);
   }
 
+  // Long 파싱
   private Long parserLong(String stringLong) {
     if (stringLong == null) {
       return null;
@@ -439,7 +446,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     return new SliceImpl<>(content, pageable, hasNext);
   }
 
-  // nextCursor(다음 페이지 커서) 조합
+  // nextCursor(다음 페이지 커서) 조합 (복합 커서)
   private String findNextCursor(ArticleDto lastArticleDto, ArticleOrderBy orderBy,
       Instant createdAt) {
     UUID lastArticleId = lastArticleDto.id();

--- a/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImpl.java
@@ -56,21 +56,24 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     // publishDate는 article table, viewCount는 article_histories table, commentCount는 comment table
     Slice<ArticleDto> articleDtoSlice =
         switch (request.getOrderBy()) {
-          case publishDate ->
-              searchArticleListByPublishDate(request, requestUserId, article, comment,
-                  articleViewAll, articleViewMe, articleInterest, pageable);
+          case publishDate -> {
+            PublishDateCursor cursor = parserPublishDateCursor(request.getCursor());
+
+            yield searchArticleListByPublishDate(request, requestUserId, article, comment,
+                articleViewAll, articleViewMe, articleInterest, cursor, pageable);
+          }
           case commentCount -> {
-            Long normalizedCursor =
-                request.getCursor() == null ? null : parserLong(request.getCursor());
+            CountCursor cursor = parserCountCursor(request.getCursor());
+
             yield searchArticleListByCommentCount(request, requestUserId, article, comment,
-                articleViewAll, articleViewMe, articleInterest, normalizedCursor,
+                articleViewAll, articleViewMe, articleInterest, cursor,
                 commentCountExpression, pageable);
           }
           case viewCount -> {
-            Long normalizedCursor =
-                request.getCursor() == null ? null : parserLong(request.getCursor());
+            CountCursor cursor = parserCountCursor(request.getCursor());
+
             yield searchArticleListByViewCount(request, requestUserId, article, comment,
-                articleViewAll, articleViewMe, articleInterest, normalizedCursor,
+                articleViewAll, articleViewMe, articleInterest, cursor,
                 viewCountExpression, pageable);
           }
         };
@@ -88,8 +91,9 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     String nextCursor = null;
     Instant after = null;
     if (articleDtoSlice.hasNext() && lastArticleDto != null) {
-      nextCursor = findNextCursor(lastArticleDto, request.getOrderBy());
-      after = findCreatedAtById(article, lastArticleDto.id());
+      Instant createdAt = findCreatedAtById(article, lastArticleDto.id());
+      nextCursor = findNextCursor(lastArticleDto, request.getOrderBy(), createdAt);
+      after = createdAt;
     }
 
     return new CursorPageResponseArticleDto(
@@ -102,16 +106,97 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     );
   }
 
+  private record PublishDateCursor(
+      Instant publishDate,
+      Instant createdAt,
+      UUID id
+  ) {
+
+  }
+
+  private record CountCursor(
+      Long count,
+      Instant createdAt,
+      UUID id
+  ) {
+
+  }
+
+  private PublishDateCursor parserPublishDateCursor(String cursor) {
+    if (cursor == null) {
+      return null;
+    }
+
+    String[] cursorParts = cursor.split("\\|", -1);
+    if (cursorParts.length != 3) {
+      throw new InvalidParameterException("cursor", cursor);
+    }
+
+    try {
+      return new PublishDateCursor(
+          parserInstant(cursorParts[0]),
+          parserInstant(cursorParts[1]),
+          parserUUID(cursorParts[2])
+      );
+    } catch (DateTimeParseException | IllegalArgumentException e) {
+      throw new InvalidParameterException("cursor", cursor);
+    }
+  }
+
+  private CountCursor parserCountCursor(String cursor) {
+    if (cursor == null) {
+      return null;
+    }
+
+    String[] cursorParts = cursor.split("\\|", -1);
+    if (cursorParts.length != 3) {
+      throw new InvalidParameterException("cursor", cursor);
+    }
+
+    try {
+      return new CountCursor(
+          parserLong(cursorParts[0]),
+          parserInstant(cursorParts[1]),
+          parserUUID(cursorParts[2])
+      );
+    } catch (DateTimeParseException | IllegalArgumentException e) {
+      throw new InvalidParameterException("cursor", cursor);
+    }
+  }
+
+  private Instant parserInstant(String stringInstant) {
+    if (stringInstant == null) {
+      return null;
+    }
+
+    return Instant.parse(stringInstant);
+  }
+
+  private UUID parserUUID(String stringId) {
+    if (stringId == null) {
+      return null;
+    }
+
+    return UUID.fromString(stringId);
+  }
+
+  private Long parserLong(String stringLong) {
+    if (stringLong == null) {
+      return null;
+    }
+
+    return Long.parseLong(stringLong);
+  }
+
   // orderBy가 publishDate일 때
   private Slice<ArticleDto> searchArticleListByPublishDate(ArticleSearchRequest request,
       UUID requestUserId, QArticle article, QComment comment, QArticleViewHistory articleViewAll,
-      QArticleViewHistory articleViewMe, QArticleInterest articleInterest, Pageable pageable) {
-
-    Instant normalizedCursor =
-        request.getCursor() == null ? null : parserInstant(request.getCursor());
+      QArticleViewHistory articleViewMe, QArticleInterest articleInterest,
+      ArticleQueryRepositoryImpl.PublishDateCursor cursor,
+      Pageable pageable) {
 
     List<ArticleDto> content = searchQueryByPublishDate(request, requestUserId, article, comment,
-        articleViewAll, articleViewMe, articleInterest, normalizedCursor);
+        articleViewAll, articleViewMe, articleInterest, cursor);
 
     // Slice 생성
     return toSlice(content, pageable);
@@ -120,11 +205,11 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   // orderBy가 commentCount일 때
   private Slice<ArticleDto> searchArticleListByCommentCount(ArticleSearchRequest request,
       UUID requestUserId, QArticle article, QComment comment, QArticleViewHistory articleViewAll,
-      QArticleViewHistory articleViewMe, QArticleInterest articleInterest, Long normalizedCursor,
+      QArticleViewHistory articleViewMe, QArticleInterest articleInterest, CountCursor cursor,
       NumberExpression<Long> commentCountExpression, Pageable pageable) {
 
     List<ArticleDto> content = searchQueryByCount(request, requestUserId, article, comment,
-        articleViewAll, articleViewMe, articleInterest, normalizedCursor, commentCountExpression);
+        articleViewAll, articleViewMe, articleInterest, cursor, commentCountExpression);
 
     // Slice 생성
     return toSlice(content, pageable);
@@ -134,11 +219,11 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   // orderBy가 viewCount일 때
   private Slice<ArticleDto> searchArticleListByViewCount(ArticleSearchRequest request,
       UUID requestUserId, QArticle article, QComment comment, QArticleViewHistory articleViewAll,
-      QArticleViewHistory articleViewMe, QArticleInterest articleInterest, Long normalizedCursor,
+      QArticleViewHistory articleViewMe, QArticleInterest articleInterest, CountCursor cursor,
       NumberExpression<Long> viewCountExpression, Pageable pageable) {
 
     List<ArticleDto> content = searchQueryByCount(request, requestUserId, article, comment,
-        articleViewAll, articleViewMe, articleInterest, normalizedCursor, viewCountExpression);
+        articleViewAll, articleViewMe, articleInterest, cursor, viewCountExpression);
 
     // Slice 생성
     return toSlice(content, pageable);
@@ -148,12 +233,12 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   List<ArticleDto> searchQueryByPublishDate(ArticleSearchRequest request, UUID requestUserId,
       QArticle article, QComment comment, QArticleViewHistory articleViewAll,
       QArticleViewHistory articleViewMe, QArticleInterest articleInterest,
-      Instant normalizedCursor) {
+      PublishDateCursor cursor) {
 
     return baseQuery(request, requestUserId, article, comment, articleViewAll, articleViewMe,
         articleInterest)
         .where(
-            publishDateCursorCondition(article, request.getDirection(), normalizedCursor,
+            publishDateCursorCondition(article, request.getDirection(), cursor,
                 request.getAfter())
         )
         .orderBy(
@@ -175,12 +260,12 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
   List<ArticleDto> searchQueryByCount(ArticleSearchRequest request, UUID requestUserId,
       QArticle article, QComment comment, QArticleViewHistory articleViewAll,
       QArticleViewHistory articleViewMe, QArticleInterest articleInterest,
-      Long normalizedCursor, NumberExpression<Long> countExpression) {
+      CountCursor cursor, NumberExpression<Long> countExpression) {
 
     return baseQuery(request, requestUserId, article, comment, articleViewAll, articleViewMe,
         articleInterest)
         .having(
-            countCursorCondition(article, request.getDirection(), normalizedCursor,
+            countCursorCondition(article, request.getDirection(), cursor,
                 request.getAfter(), countExpression)
         )
         .orderBy(
@@ -260,30 +345,6 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     };
   }
 
-  private Instant parserInstant(String cursor) {
-    if (cursor == null) {
-      return null;
-    }
-
-    try {
-      return Instant.parse(cursor);
-    } catch (DateTimeParseException e) {
-      throw new InvalidParameterException("cursor", cursor);
-    }
-  }
-
-  private Long parserLong(String cursor) {
-    if (cursor == null) {
-      return null;
-    }
-
-    try {
-      return Long.parseLong(cursor);
-    } catch (NumberFormatException e) {
-      throw new InvalidParameterException("cursor", cursor);
-    }
-  }
-
   private BooleanExpression keywordContains(QArticle article, String keyword) {
     // ""일 경우를 `null` 을 가지게 하기 위해 `isBlank()` 조건 추가
     return keyword != null && !keyword.isBlank()
@@ -315,41 +376,56 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
   // orderBy가 publishDate일 때 커서 조건
   private BooleanExpression publishDateCursorCondition(QArticle article, ArticleDirection direction,
-      Instant cursor, Instant after) {
+      PublishDateCursor cursor, Instant after) {
 
-    if (cursor == null || after == null) {
+    if (cursor == null) {
       return null;
     }
 
     // `lt` -> `<` 미만
     if (direction == ArticleDirection.DESC) {
-      return article.publishDate.lt(cursor)
-          .or(article.publishDate.eq(cursor).and(article.createdAt.lt(after)));
+      return article.publishDate.lt(cursor.publishDate())
+          .or(article.publishDate.eq(cursor.publishDate())
+              .and(article.createdAt.lt(cursor.createdAt())))
+          .or(article.publishDate.eq(cursor.publishDate())
+              .and(article.createdAt.eq(cursor.createdAt()))
+              .and(article.id.lt(cursor.id())));
     }
 
     // `gt` -> `>` 초과
-    return article.publishDate.gt(cursor)
-        .or(article.publishDate.eq(cursor).and(article.createdAt.gt(after)));
+    return article.publishDate.gt(cursor.publishDate())
+        .or(article.publishDate.eq(cursor.publishDate())
+            .and(article.createdAt.gt(cursor.createdAt())))
+        .or(article.publishDate.eq(cursor.publishDate())
+            .and(article.createdAt.eq(cursor.createdAt()))
+            .and(article.id.gt(cursor.id())));
   }
 
   // orderBy가 commentCount/viewCount일 때 커서 조건
-  private BooleanExpression countCursorCondition(QArticle article,
-      ArticleDirection direction, Long cursor, Instant after,
-      NumberExpression<Long> countExpression) {
+  private BooleanExpression countCursorCondition(QArticle article, ArticleDirection direction,
+      CountCursor cursor, Instant after, NumberExpression<Long> countExpression) {
 
-    if (cursor == null || after == null) {
+    if (cursor == null) {
       return null;
     }
 
     // `lt` -> `<` 미만
     if (direction == ArticleDirection.DESC) {
-      return countExpression.lt(cursor)
-          .or(countExpression.eq(cursor).and(article.createdAt.lt(after)));
+      return countExpression.lt(cursor.count())
+          .or(countExpression.eq(cursor.count())
+              .and(article.createdAt.lt(cursor.createdAt())))
+          .or(countExpression.eq(cursor.count())
+              .and(article.createdAt.eq(cursor.createdAt()))
+              .and(article.id.lt(cursor.id())));
     }
 
     // `gt` -> `>` 초과
-    return countExpression.gt(cursor)
-        .or(countExpression.eq(cursor).and(article.createdAt.gt(after)));
+    return countExpression.gt(cursor.count())
+        .or(countExpression.eq(cursor.count())
+            .and(article.createdAt.gt(cursor.createdAt())))
+        .or(countExpression.eq(cursor.count())
+            .and(article.createdAt.eq(cursor.createdAt()))
+            .and(article.id.gt(cursor.id())));
   }
 
   // Slice 생성 메서드
@@ -363,12 +439,33 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     return new SliceImpl<>(content, pageable, hasNext);
   }
 
-  // nextCursor(다음 페이지 커서) 찾기
-  private String findNextCursor(ArticleDto lastArticleDto, ArticleOrderBy orderBy) {
+  // nextCursor(다음 페이지 커서) 조합
+  private String findNextCursor(ArticleDto lastArticleDto, ArticleOrderBy orderBy,
+      Instant createdAt) {
+    UUID lastArticleId = lastArticleDto.id();
+
     return switch (orderBy) {
-      case publishDate -> lastArticleDto.publishDate().toString();
-      case commentCount -> String.valueOf(lastArticleDto.commentCount());
-      case viewCount -> String.valueOf(lastArticleDto.viewCount());
+      // "publishDate|createdAt|articleId"
+      case publishDate -> String.join(
+          "|",
+          lastArticleDto.publishDate().toString(),
+          createdAt.toString(),
+          lastArticleId.toString()
+      );
+      // "commentCount|createdAt|articleId"
+      case commentCount -> String.join(
+          "|",
+          String.valueOf(lastArticleDto.commentCount()),
+          createdAt.toString(),
+          lastArticleId.toString()
+      );
+      // "viewCount|createdAt|articleId"
+      case viewCount -> String.join(
+          "|",
+          String.valueOf(lastArticleDto.viewCount()),
+          createdAt.toString(),
+          lastArticleId.toString()
+      );
     };
   }
 

--- a/src/test/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImplTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/repository/impl/ArticleQueryRepositoryImplTest.java
@@ -152,7 +152,6 @@ public class ArticleQueryRepositoryImplTest {
           result.content().get(1).publishDate());
 
       assertThat(result.hasNext()).isTrue();
-      assertThat(result.nextCursor()).isEqualTo(article2.getPublishDate().toString());
       assertThat(result.nextAfter()).isNotNull();
       assertThat(result.totalElements()).isEqualTo(3);
     }
@@ -209,7 +208,6 @@ public class ArticleQueryRepositoryImplTest {
       assertThat(result.content().get(1).commentCount()).isEqualTo(2);
 
       assertThat(result.hasNext()).isTrue();
-      assertThat(result.nextCursor()).isEqualTo("2");
       assertThat(result.nextAfter()).isNotNull();
       assertThat(result.totalElements()).isEqualTo(3);
     }
@@ -266,7 +264,6 @@ public class ArticleQueryRepositoryImplTest {
       assertThat(result.content().get(1).viewCount()).isEqualTo(2);
 
       assertThat(result.hasNext()).isTrue();
-      assertThat(result.nextCursor()).isEqualTo("2");
       assertThat(result.nextAfter()).isNotNull();
       assertThat(result.totalElements()).isEqualTo(3);
     }


### PR DESCRIPTION
## 📝작업 내용

뉴스 기사 목록 조회에서 무한 스크롤 조회를 할 때, 프론트엔드에서 `cursor`만 전달하고 `after`는 전달하지 않음으로 인해 아래 문제들이 발생한 것을 수정

- 다음 페이지 요청 시 커스텀 예외 `InvalidParameterException`이 발생하던 문제 수정
  - Controller에서 `cursor`와` after`가 동시 존재해야 하는 검증 로직 제거
- `after` 미사용 문제로 일부 뉴스 기사 데이터가 생략되는 문제 수정
  - `cursor` + `after` 페이지네이션 방식이 아닌 `cursor`를 정렬 기준 값 + `createdAt` + `articleId`으로 조합해 전송
    - `publishDate`라면 `publishDate|createdAt|articleId`
    - `commentCount`라면 `commentCount|createdAt|articleId`

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## #️⃣연관된 이슈

Closes #118 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 검색 API의 파라미터 검증이 완화되어 일부 요청(특정 페이징 파라미터 조합)이 이제 정상 처리됩니다.
* **개선**
  * 페이지네이션의 커서 형식이 개선되어 다음 페이지 이동이 더 안정적이고 일관되게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->