### PR TITLE
[fix] 관심사 기능 로직 관련 오류 해결

### DIFF
--- a/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/codeit/monew/domain/interest/controller/InterestController.java
@@ -9,8 +9,6 @@ import com.codeit.monew.domain.interest.service.InterestService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -70,12 +68,11 @@ public class InterestController {
       @RequestParam String orderBy,
       @RequestParam String direction,
       @RequestParam(required = false) String cursor,
-      @RequestParam(required = false) Instant after,
       @RequestParam @Min(1) @Max(100) int limit, // 과도한 조회/예외 가능성 방지를 위한 가드 추가
       @RequestHeader("Monew-Request-User-ID") UUID userId
   ) {
     CursorPageResponseInterestDto response = interestService.getList(
-        keyword, orderBy, direction, cursor, after, limit, userId
+        keyword, orderBy, direction, cursor, limit, userId
     );
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -1,13 +1,10 @@
 package com.codeit.monew.domain.interest.dto.response;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record CursorPageResponseInterestDto(
     List<InterestDto> content,
     String nextCursor,
-    Instant nextAfter,
     int size,
     long totalElements,
     boolean hasNext

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepository.java
@@ -3,6 +3,7 @@ package com.codeit.monew.domain.interest.repository;
 import com.codeit.monew.domain.interest.entity.Interest;
 import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -25,4 +26,8 @@ public interface InterestRepository extends JpaRepository<Interest, UUID>, Inter
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("UPDATE Interest i SET i.subscriberCount = i.subscriberCount - 1 WHERE i.id = :id AND i.subscriberCount > 0")
   int decrementSubscriberCount(@Param("id") UUID id);
+
+  // 구독 응답 키워드 포함을 위해 키워드 fetch join으로 함께 조회
+  @Query("SELECT i FROM Interest i LEFT JOIN FETCH i.keywords WHERE i.id = :id")
+  Optional<Interest> findByIdWithKeywords(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryCustom.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryCustom.java
@@ -10,7 +10,6 @@ public interface InterestRepositoryCustom {
       String orderBy,
       String direction,
       String cursor,
-      Instant after,
       int limit,
       UUID userId
   );

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -192,14 +192,12 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     if ("name".equals(orderBy)) {
       return new OrderSpecifier[]{
           isAsc ? interest.name.asc() : interest.name.desc(),
-          isAsc ? interest.createdAt.asc() : interest.createdAt.desc(),
-          interest.id.asc()  // tie-breaker
+          isAsc ? interest.id.asc() : interest.id.desc()
       };
     } else {
       return new OrderSpecifier[]{
           isAsc ? interest.subscriberCount.asc() : interest.subscriberCount.desc(),
-          isAsc ? interest.createdAt.asc() : interest.createdAt.desc(),
-          interest.id.asc()  // tie-breaker
+          isAsc ? interest.id.asc() : interest.id.desc()
       };
     }
   }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -10,7 +10,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -127,8 +126,8 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
   /**
    * 커서 기반 페이지네이션 조건 생성
    * 정렬 기준(name/subscriberCount)과 방향(ASC/DESC)에 따라 커서 조건 생성
-   * 동일값 존재 시 createdAt으로 tie-breaking 처리
-   * cursor 또는 after가 없으면 null 반환 (첫 페이지)
+   * cursor는 'value::uuid' 형식이며 uuid로 tie-breaking 처리
+   * cursor가 없으면 null 반환 (첫 페이지)
    */
   private BooleanExpression buildCursorCondition(String orderBy, String direction, String cursor) {
     validateSortArgs(orderBy, direction);
@@ -137,31 +136,29 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
 
     // cursor 파싱
     String[] parts = cursor.split("::", 2);
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("잘못된 cursor 형식입니다. cursor는 'value::uuid' 형식이어야 합니다: " + cursor);
+    }
     String cursorValue = parts[0];
-    UUID cursorId = null;
-    if (parts.length > 1) {
-      try {
-        cursorId = UUID.fromString(parts[1]);
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException("잘못된 cursor ID 형식입니다: " + parts[1]);
-      }
+    UUID cursorId;
+    try {
+      cursorId = UUID.fromString(parts[1]);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("잘못된 cursor ID 형식입니다: " + parts[1]);
     }
 
     boolean isAsc = "ASC".equalsIgnoreCase(direction);
-    UUID finalCursorId = cursorId;
 
     if ("name".equals(orderBy)) {
       return isAsc
           ? interest.name.gt(cursorValue)
           .or(interest.name.eq(cursorValue)
-              .and(finalCursorId != null ?
-                  Expressions.stringTemplate("cast({0} as text)", interest.id)
-                      .gt(finalCursorId.toString()) : null))
+              .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
+                  .gt(cursorId.toString())))
           : interest.name.lt(cursorValue)
               .or(interest.name.eq(cursorValue)
-                  .and(finalCursorId != null ?
-                      Expressions.stringTemplate("cast({0} as text)", interest.id)
-                          .lt(finalCursorId.toString()) : null));
+                  .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
+                      .lt(cursorId.toString())));
     } else {
       long cursorLong;
       try {
@@ -172,14 +169,12 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       return isAsc
           ? interest.subscriberCount.gt(cursorLong)
           .or(interest.subscriberCount.eq(cursorLong)
-              .and(finalCursorId != null ?
-                  Expressions.stringTemplate("cast({0} as text)", interest.id)
-                      .gt(finalCursorId.toString()) : null))
+              .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
+                  .gt(cursorId.toString())))
           : interest.subscriberCount.lt(cursorLong)
               .or(interest.subscriberCount.eq(cursorLong)
-                  .and(finalCursorId != null ?
-                      Expressions.stringTemplate("cast({0} as text)", interest.id)
-                          .lt(finalCursorId.toString()) : null));
+                  .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
+                      .lt(cursorId.toString())));
     }
   }
 

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,9 +91,10 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     String nextCursor = null;
     if (hasNext && !interests.isEmpty()) {
       Interest last = interests.get(interests.size() - 1);
-      nextCursor = "name".equals(orderBy)
+      String raw = "name".equals(orderBy)
           ? last.getName() + "::" + last.getId()
           : last.getSubscriberCount() + "::" + last.getId();
+      nextCursor = Base64.getEncoder().encodeToString(raw.getBytes());
     }
 
     // 8. totalElements
@@ -126,7 +128,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
   /**
    * 커서 기반 페이지네이션 조건 생성
    * 정렬 기준(name/subscriberCount)과 방향(ASC/DESC)에 따라 커서 조건 생성
-   * cursor는 'value::uuid' 형식이며 uuid로 tie-breaking 처리
+   * cursor는 Base64로 인코딩된 'value::uuid' 형식이며 uuid로 tie-breaking 처리
    * cursor가 없으면 null 반환 (첫 페이지)
    */
   private BooleanExpression buildCursorCondition(String orderBy, String direction, String cursor) {
@@ -135,7 +137,8 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       return null;
 
     // cursor 파싱
-    String[] parts = cursor.split("::", 2);
+    String decoded = new String(Base64.getDecoder().decode(cursor));
+    String[] parts = decoded.split("::", 2);
     if (parts.length != 2) {
       throw new IllegalArgumentException("잘못된 cursor 형식입니다. cursor는 'value::uuid' 형식이어야 합니다: " + cursor);
     }

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -94,7 +94,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       String raw = "name".equals(orderBy)
           ? last.getName() + "::" + last.getId()
           : last.getSubscriberCount() + "::" + last.getId();
-      nextCursor = Base64.getEncoder().encodeToString(raw.getBytes());
+      nextCursor = Base64.getEncoder().encodeToString(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 
     // 8. totalElements
@@ -137,7 +137,12 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       return null;
 
     // cursor 파싱
-    String decoded = new String(Base64.getDecoder().decode(cursor));
+    String decoded;
+    try {
+      decoded = new String(Base64.getDecoder().decode(cursor), java.nio.charset.StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+       throw new IllegalArgumentException("잘못된 cursor 인코딩입니다: " + cursor);
+    }
     String[] parts = decoded.split("::", 2);
     if (parts.length != 2) {
       throw new IllegalArgumentException("잘못된 cursor 형식입니다. cursor는 'value::uuid' 형식이어야 합니다: " + cursor);

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -91,9 +91,11 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     String nextCursor = null;
     if (hasNext && !interests.isEmpty()) {
       Interest last = interests.get(interests.size() - 1);
-      String raw = "name".equals(orderBy)
-          ? last.getName() + "::" + last.getId()
-          : last.getSubscriberCount() + "::" + last.getId();
+      String valueToken = "name".equals(orderBy)
+          ? Base64.getUrlEncoder().withoutPadding()
+          .encodeToString(last.getName().getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          : String.valueOf(last.getSubscriberCount());
+      String raw = valueToken + "::" + last.getId();
       nextCursor = Base64.getEncoder().encodeToString(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8));
     }
 
@@ -147,7 +149,9 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     if (parts.length != 2) {
       throw new IllegalArgumentException("잘못된 cursor 형식입니다. cursor는 'value::uuid' 형식이어야 합니다: " + cursor);
     }
-    String cursorValue = parts[0];
+    String cursorValue = "name".equals(orderBy)
+        ? new String(Base64.getUrlDecoder().decode(parts[0]), java.nio.charset.StandardCharsets.UTF_8)
+        : parts[0];
     UUID cursorId;
     try {
       cursorId = UUID.fromString(parts[1]);

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -189,7 +189,7 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
   /**
    * 정렬 조건 생성
    * 정렬 기준(name/subscriberCount)과 방향(ASC/DESC)에 따라 정렬 조건 생성
-   * 동일값 존재 시 createdAt을 보조 정렬 기준으로 사용
+   * 동일값 존재 시 id를 보조 정렬 기준으로 사용 (tie-breaking)
    */
   private OrderSpecifier<?>[] buildOrderSpecifiers(String orderBy, String direction) {
     validateSortArgs(orderBy, direction);

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.codeit.monew.domain.interest.entity.QKeyword;
 import com.codeit.monew.domain.interest.entity.QSubscription;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.Instant;
 import java.util.HashSet;
@@ -32,14 +33,14 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
 
   @Override
   public CursorPageResponseInterestDto findInterests(String searchKeyword, String orderBy,
-      String direction, String cursor, Instant after, int limit, UUID userId) {
+      String direction, String cursor, int limit, UUID userId) {
     // 1. 검색 + 커서 조건으로 Interest 엔티티 조회
     List<Interest> interests = queryFactory
         .selectFrom(interest)
         .leftJoin(interest.keywords, keyword)
         .where(
             buildSearchCondition(searchKeyword),
-            buildCursorCondition(orderBy, direction, cursor, after)
+            buildCursorCondition(orderBy, direction, cursor)
         )
         .groupBy(interest.id)
         .orderBy(buildOrderSpecifiers(orderBy, direction))
@@ -86,15 +87,13 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
         .map(i -> InterestDto.from(i, subscribedIds.contains(i.getId())))
         .toList();
 
-    // 7. nextCursor, nextAfter 계산
+    // 7. nextCursor 계산
     String nextCursor = null;
-    Instant nextAfter = null;
     if (hasNext && !interests.isEmpty()) {
       Interest last = interests.get(interests.size() - 1);
       nextCursor = "name".equals(orderBy)
           ? last.getName() + "::" + last.getId()
           : last.getSubscriberCount() + "::" + last.getId();
-      nextAfter = last.getCreatedAt();
     }
 
     // 8. totalElements
@@ -108,7 +107,6 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     return new CursorPageResponseInterestDto(
         content,
         nextCursor,
-        nextAfter,
         content.size(),
         totalElements != null ? totalElements : 0L,
         hasNext
@@ -132,12 +130,10 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
    * 동일값 존재 시 createdAt으로 tie-breaking 처리
    * cursor 또는 after가 없으면 null 반환 (첫 페이지)
    */
-  private BooleanExpression buildCursorCondition(String orderBy, String direction, String cursor, Instant after) {
+  private BooleanExpression buildCursorCondition(String orderBy, String direction, String cursor) {
     validateSortArgs(orderBy, direction);
-    if ((cursor == null) != (after == null)) {
-      throw new IllegalArgumentException("cursor와 after는 함께 전달되어야 합니다.");
-    }
-    if (cursor == null) return null;
+    if (cursor == null)
+      return null;
 
     // cursor 파싱
     String[] parts = cursor.split("::", 2);
@@ -152,19 +148,20 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
     }
 
     boolean isAsc = "ASC".equalsIgnoreCase(direction);
+    UUID finalCursorId = cursorId;
 
     if ("name".equals(orderBy)) {
       return isAsc
           ? interest.name.gt(cursorValue)
-          .or(interest.name.eq(cursorValue).and(interest.createdAt.gt(after)))
           .or(interest.name.eq(cursorValue)
-              .and(interest.createdAt.eq(after))
-              .and(cursorId != null ? interest.id.gt(cursorId) : null))
+              .and(finalCursorId != null ?
+                  Expressions.stringTemplate("cast({0} as text)", interest.id)
+                      .gt(finalCursorId.toString()) : null))
           : interest.name.lt(cursorValue)
-              .or(interest.name.eq(cursorValue).and(interest.createdAt.lt(after)))
               .or(interest.name.eq(cursorValue)
-                  .and(interest.createdAt.eq(after))
-                  .and(cursorId != null ? interest.id.gt(cursorId) : null));
+                  .and(finalCursorId != null ?
+                      Expressions.stringTemplate("cast({0} as text)", interest.id)
+                          .lt(finalCursorId.toString()) : null));
     } else {
       long cursorLong;
       try {
@@ -174,15 +171,15 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       }
       return isAsc
           ? interest.subscriberCount.gt(cursorLong)
-          .or(interest.subscriberCount.eq(cursorLong).and(interest.createdAt.gt(after)))
           .or(interest.subscriberCount.eq(cursorLong)
-              .and(interest.createdAt.eq(after))
-              .and(cursorId != null ? interest.id.gt(cursorId) : null))
+              .and(finalCursorId != null ?
+                  Expressions.stringTemplate("cast({0} as text)", interest.id)
+                      .gt(finalCursorId.toString()) : null))
           : interest.subscriberCount.lt(cursorLong)
-              .or(interest.subscriberCount.eq(cursorLong).and(interest.createdAt.lt(after)))
               .or(interest.subscriberCount.eq(cursorLong)
-                  .and(interest.createdAt.eq(after))
-                  .and(cursorId != null ? interest.id.gt(cursorId) : null));
+                  .and(finalCursorId != null ?
+                      Expressions.stringTemplate("cast({0} as text)", interest.id)
+                          .lt(finalCursorId.toString()) : null));
     }
   }
 

--- a/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -161,12 +161,10 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       return isAsc
           ? interest.name.gt(cursorValue)
           .or(interest.name.eq(cursorValue)
-              .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
-                  .gt(cursorId.toString())))
+              .and(interest.id.gt(cursorId)))
           : interest.name.lt(cursorValue)
               .or(interest.name.eq(cursorValue)
-                  .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
-                      .lt(cursorId.toString())));
+                  .and(interest.id.lt(cursorId)));
     } else {
       long cursorLong;
       try {
@@ -177,12 +175,10 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom{
       return isAsc
           ? interest.subscriberCount.gt(cursorLong)
           .or(interest.subscriberCount.eq(cursorLong)
-              .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
-                  .gt(cursorId.toString())))
+              .and(interest.id.gt(cursorId)))
           : interest.subscriberCount.lt(cursorLong)
               .or(interest.subscriberCount.eq(cursorLong)
-                  .and(Expressions.stringTemplate("cast({0} as text)", interest.id)
-                      .lt(cursorId.toString())));
+                  .and(interest.id.lt(cursorId)));
     }
   }
 

--- a/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
@@ -20,7 +20,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
   @Transactional
   @Modifying
   @Query("DELETE FROM Subscription s WHERE s.user.id = :userId AND s.interest.id = :interestId")
-  long deleteByUserIdAndInterestId(UUID userId, UUID interestId);
+  int deleteByUserIdAndInterestId(UUID userId, UUID interestId);
 
   List<Subscription> findByInterestIdIn(Collection<UUID> interestIds);
 

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -114,12 +114,11 @@ public class InterestService {
       String orderBy,
       String direction,
       String cursor,
-      Instant after,
       int limit,
       UUID userId
   ) {
     return interestRepository.findInterests(
-        searchKeyword, orderBy, direction, cursor, after, limit, userId
+        searchKeyword, orderBy, direction, cursor, limit, userId
     );
   }
 

--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -82,6 +82,7 @@ public class InterestService {
 
     // 기존 키워드 전체 삭제
     keywordRepository.deleteAllByInterestId(interestId);
+    keywordRepository.flush();  // 삭제 먼저 DB에 반영
 
     // 새 키워드 저장
     List<Keyword> keywords = request.keywords().stream()
@@ -127,7 +128,7 @@ public class InterestService {
   public SubscriptionDto subscribe(UUID interestId, UUID userId) {
 
     // 관심사 존재 여부 확인
-    Interest interest = interestRepository.findById(interestId)
+    Interest interest = interestRepository.findByIdWithKeywords(interestId)
         .orElseThrow(() -> new InterestNotFoundException(interestId));
 
     // 사용자 존재 여부 확인
@@ -170,7 +171,7 @@ public class InterestService {
         .orElseThrow(() -> new InterestNotFoundException(interestId));
 
     // 구독 여부 확인 및 구독 취소
-    long deleted = subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
+    int deleted = subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId);
     if (deleted == 0) {
       throw new SubscriptionNotFoundException(userId, interestId);
     }

--- a/src/test/java/com/codeit/monew/domain/interest/repository/InterestRepositoryTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/repository/InterestRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.codeit.monew.domain.interest.repository;
+
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.interest.entity.Keyword;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.config.JpaAuditingConfig;
+import com.codeit.monew.global.config.QueryDslConfig;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest(showSql = false)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class InterestRepositoryTest {
+
+  @Autowired
+  private InterestRepository interestRepository;
+
+  @Autowired
+  private KeywordRepository keywordRepository;
+
+  @Autowired
+  private SubscriptionRepository subscriptionRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private TestEntityManager testEntityManager;
+
+  // 매 테스트 전 이전 테스트 데이터 비우고 시작
+  @BeforeEach
+  void setUp() {
+    subscriptionRepository.deleteAll();
+    keywordRepository.deleteAll();
+    interestRepository.deleteAll();
+    userRepository.deleteAll();
+  }
+
+  private Interest createInterest(String name, List<String> keywords) {
+    Interest interest = Interest.create(name);
+    interestRepository.save(interest);
+    keywords.forEach(k -> keywordRepository.save(Keyword.create(interest, k)));
+    testEntityManager.flush();
+    testEntityManager.clear();
+    return interest;
+  }
+
+  private User createUser(String email) {
+    User user = new User(email, "nickname", "password");
+    return userRepository.save(user);
+  }
+
+}

--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -335,7 +335,7 @@ class InterestServiceTest {
       Interest interest = createInterest(interestId, "스포츠");
 
       given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
-      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(1L);
+      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(1);
 
       // when
       interestService.unsubscribe(interestId, userId);
@@ -370,7 +370,7 @@ class InterestServiceTest {
       Interest interest = createInterest(interestId, "스포츠");
 
       given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
-      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(0L);
+      given(subscriptionRepository.deleteByUserIdAndInterestId(userId, interestId)).willReturn(0);
 
       // when, then
       assertThrows(SubscriptionNotFoundException.class,

--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -197,19 +197,18 @@ class InterestServiceTest {
       CursorPageResponseInterestDto expected = new CursorPageResponseInterestDto(
           List.of(interestDto),
           null,
-          null,
           1,
           1L,
           false
       );
 
       given(interestRepository.findInterests(
-          null, "name", "ASC", null, null, 10, userId
+          null, "name", "ASC", null, 10, userId
       )).willReturn(expected);
 
       // when
       CursorPageResponseInterestDto result = interestService.getList(
-          null, "name", "ASC", null, null, 10, userId
+          null, "name", "ASC", null, 10, userId
       );
 
       // then
@@ -218,7 +217,7 @@ class InterestServiceTest {
       assertEquals("스포츠", result.content().get(0).name());
       assertFalse(result.hasNext());
       verify(interestRepository).findInterests(
-          null, "name", "ASC", null, null, 10, userId
+          null, "name", "ASC", null, 10, userId
       );
     }
 
@@ -231,19 +230,18 @@ class InterestServiceTest {
       CursorPageResponseInterestDto expected = new CursorPageResponseInterestDto(
           List.of(),
           null,
-          null,
           0,
           0L,
           false
       );
 
       given(interestRepository.findInterests(
-          "없는검색어", "name", "ASC", null, null, 10, userId
+          "없는검색어", "name", "ASC", null, 10, userId
       )).willReturn(expected);
 
       // when
       CursorPageResponseInterestDto result = interestService.getList(
-          "없는검색어", "name", "ASC", null, null, 10, userId
+          "없는검색어", "name", "ASC", null, 10, userId
       );
 
       // then
@@ -267,7 +265,7 @@ class InterestServiceTest {
       User user = new User("test@email.com", "testNickname", "testPassword");
       ReflectionTestUtils.setField(user, "id", userId);
 
-      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(interestRepository.findByIdWithKeywords(interestId)).willReturn(Optional.of(interest));
       given(userRepository.findById(userId)).willReturn(Optional.of(user));
       given(subscriptionRepository.save(any())).willAnswer(i -> i.getArgument(0));
 
@@ -288,7 +286,7 @@ class InterestServiceTest {
       UUID interestId = UUID.randomUUID();
       UUID userId = UUID.randomUUID();
 
-      given(interestRepository.findById(interestId)).willReturn(Optional.empty());
+      given(interestRepository.findByIdWithKeywords(interestId)).willReturn(Optional.empty());
 
       // when, then
       assertThrows(InterestNotFoundException.class,
@@ -307,7 +305,7 @@ class InterestServiceTest {
       User user = new User("test@email.com", "testNickname", "testPassword");
       ReflectionTestUtils.setField(user, "id", userId);
 
-      given(interestRepository.findById(interestId)).willReturn(Optional.of(interest));
+      given(interestRepository.findByIdWithKeywords(interestId)).willReturn(Optional.of(interest));
       given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
       // DB UNIQUE 제약 위반 Mock


### PR DESCRIPTION
## #️⃣연관된 이슈

관심사 기능 구현 전반

## 📝작업 내용

- 키워드 수정 시 중복 키워드 오류 해결 (`keywordRepository.flush() `추가)
- 구독 `subscriptionRepository.deleteByUserIdAndInterestId` 메소드 반환 타입 수정 (`long` -> `int`)
- 구독 시 `LazyInitializationException` 오류 해결 (`findByIdWithKeywords`로 변경)
- 커서 페이지네이션 오류 해결 (`nextAfter` 제거)

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- `nextAfter` 제거에 따른 영향 범위 검토해주시면 감사하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 목록 조회에서 `after` 파라미터 및 응답의 타임스탬프(nextAfter) 제거, 커서 처리·정렬·타이브레이크 단순화(값::UUID 기반)

* **기능 개선**
  * 구독 시 연관 키워드를 함께 즉시 로드하도록 조회 방식 변경
  * 키워드 갱신 직후 삭제 결과를 즉시 반영하도록 저장 흐름 보장

* **버그 수정**
  * 구독 해제 삭제 반환 타입 변경에 따른 정상/오류 처리 보완

* **테스트**
  * 단위 테스트 업데이트 및 JPA 리포지토리 테스트 클래스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->