### PR TITLE
[feat] 알림 생성 로직 구현

### DIFF
--- a/src/main/java/com/codeit/monew/MonewApplication.java
+++ b/src/main/java/com/codeit/monew/MonewApplication.java
@@ -4,11 +4,13 @@ import com.codeit.monew.global.config.AwsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(AwsProperties.class)
 @EnableScheduling
+@EnableAsync
 public class MonewApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
+++ b/src/main/java/com/codeit/monew/domain/interest/repository/SubscriptionRepository.java
@@ -24,4 +24,11 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
 
   List<Subscription> findByInterestIdIn(Collection<UUID> interestIds);
 
+  // 구독한 관심사 관련 기사 알림 생성용
+  @Query("SELECT s FROM Subscription s " +
+      "JOIN FETCH s.user " +
+      "JOIN FETCH s.interest " +
+      "WHERE s.interest.id IN :interestIds")
+  List<Subscription> findAllByInterestIdInWithUserAndInterest(@Param("interestIds") List<UUID> interestIds);
+
 }

--- a/src/main/java/com/codeit/monew/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/codeit/monew/domain/notification/dto/NotificationDto.java
@@ -1,0 +1,34 @@
+package com.codeit.monew.domain.notification.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+
+    @Schema(description = "알림 ID")
+    UUID id,
+
+    @Schema(description = "알림 생성 일시")
+    Instant createdAt,
+
+    @Schema(description = "알림 수정 일시")
+    Instant updatedAt,
+
+    @Schema(description = "알림 확인 여부")
+    boolean confirmed,
+
+    @Schema(description = "알림을 받을 사용자 ID")
+    UUID userId,
+
+    @Schema(description = "알림 내용")
+    String content,
+
+    @Schema(description = "관련 리소스 타입 (INTEREST 또는 COMMENT)")
+    String resourceType,
+
+    @Schema(description = "관련 리소스 ID (관심사 ID 또는 댓글 ID)")
+    UUID resourceId
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/notification/entity/CommentNotification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/CommentNotification.java
@@ -1,0 +1,45 @@
+package com.codeit.monew.domain.notification.entity;
+
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.user.entity.User;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 댓글 좋아요 알림 자식 클래스
+@Entity
+@DiscriminatorValue("COMMENT") // 자원 타입(resource_type) 칼럼에 "COMMENT" 할당
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentNotification extends Notification{
+
+  // 댓글
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "comment_id")
+  private Comment comment;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private CommentNotification(User user, String content, Comment comment) {
+    super(user, content); // 부모 생성자 호출하여 user, content 할당 및 검증
+
+    if (comment == null) {
+      throw new IllegalArgumentException("댓글 알림에는 대상 댓글 엔티티가 필수입니다.");
+    }
+    this.comment = comment;
+  }
+
+  // 정적 팩토리 메서드
+  public static CommentNotification create(User user, String content, Comment comment) {
+    return CommentNotification.builder()
+        .user(user)
+        .content(content)
+        .comment(comment)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/notification/entity/InterestNotification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/InterestNotification.java
@@ -1,0 +1,45 @@
+package com.codeit.monew.domain.notification.entity;
+
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.user.entity.User;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 관심사 관련 기사 알림 자식 클래스
+@Entity
+@DiscriminatorValue("INTEREST") // 자원 타입(resource_type) 칼럼에 "INTEREST" 할당
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestNotification extends Notification{
+
+  // 관심사
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "interest_id")
+  private Interest interest;
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private InterestNotification(User user, String content, Interest interest) {
+    super(user, content); // 부모 생성자 호출하여 user, content 할당 및 검증
+
+    if (interest == null) {
+      throw new IllegalArgumentException("관심사 알림에는 대상 관심사 엔티티가 필수입니다.");
+    }
+    this.interest = interest;
+  }
+
+  // 정적 팩토리 메서드
+  public static InterestNotification create(User user, String content, Interest interest) {
+    return InterestNotification.builder()
+        .user(user)
+        .content(content)
+        .interest(interest)
+        .build();
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
@@ -1,0 +1,64 @@
+package com.codeit.monew.domain.notification.entity;
+
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.global.common.base.BaseUpdatableEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notifications", indexes = {
+    @Index(name = "idx_notification_user_confirmed_created", columnList = "user_id, confirmed, created_at DESC")
+})
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE) // resource 필드에 기사/댓글 모두 할당 가능하게 하기 위해 자식 클래스 생성
+@DiscriminatorColumn(name = "resource_type") // 자원 타입
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseUpdatableEntity {
+
+  // 사용자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  // 알림 내용
+  @Column(name = "content", nullable = false, length = 500)
+  private String content;
+
+  // 알림 확인 여부
+  @Column(name = "confirmed", nullable = false)
+  private boolean confirmed = false;
+
+  // 자식 클래스에서 호출할 생성자
+  protected Notification(User user, String content) {
+    validateNotification(user, content); // 생성 시 내부 검증 로직 실행
+    this.user = user;
+    this.content = content;
+    this.confirmed = false;
+  }
+
+  // 엔티티 무결성 검증 로직
+  private void validateNotification(User user, String content) {
+    if (user == null || content == null || content.isBlank()) {
+      throw new IllegalArgumentException("알림 생성 시 필수 값이 누락되었습니다.");
+    }
+    if (content.length() > 500) {
+      throw new IllegalArgumentException("알림 내용이 제한 길이를 초과했습니다.");
+    }
+  }
+
+  // 비즈니스 로직 - 알림 읽음 처리
+  public void confirm() {
+    this.confirmed = true;
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/notification/event/BulkArticleRegisteredEvent.java
+++ b/src/main/java/com/codeit/monew/domain/notification/event/BulkArticleRegisteredEvent.java
@@ -1,0 +1,15 @@
+package com.codeit.monew.domain.notification.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record BulkArticleRegisteredEvent(
+    List<InterestArticleCount> interestCounts
+) {
+  // 기사 알림 생성에 필요한 최소한의 데이터만 묶은 레코드
+  public record InterestArticleCount(
+      UUID interestId, // 관심사 ID
+      String interestName, // 관심사 이름
+      long articleCount // 새로 등록된 기사 수
+  ) {}
+}

--- a/src/main/java/com/codeit/monew/domain/notification/event/BulkArticleRegisteredEvent.java
+++ b/src/main/java/com/codeit/monew/domain/notification/event/BulkArticleRegisteredEvent.java
@@ -6,10 +6,24 @@ import java.util.UUID;
 public record BulkArticleRegisteredEvent(
     List<InterestArticleCount> interestCounts
 ) {
+  // 방어적 복사본 생성으로 불변성 보장
+  public BulkArticleRegisteredEvent {
+    interestCounts = (interestCounts == null) ? List.of() : List.copyOf(interestCounts);
+  }
+
   // 기사 알림 생성에 필요한 최소한의 데이터만 묶은 레코드
   public record InterestArticleCount(
       UUID interestId, // 관심사 ID
       String interestName, // 관심사 이름
       long articleCount // 새로 등록된 기사 수
-  ) {}
+  ) {
+    public InterestArticleCount {
+      if (interestId == null) {
+        throw new IllegalArgumentException("관심사 ID는 null일 수 없습니다.");
+      }
+      if (articleCount < 0) {
+        throw new IllegalArgumentException("기사 수는 0보다 작을 수 없습니다.");
+      }
+    }
+  }
 }

--- a/src/main/java/com/codeit/monew/domain/notification/event/CommentLikedEvent.java
+++ b/src/main/java/com/codeit/monew/domain/notification/event/CommentLikedEvent.java
@@ -1,0 +1,12 @@
+package com.codeit.monew.domain.notification.event;
+
+import java.util.UUID;
+
+public record CommentLikedEvent(
+    UUID commentId,
+    UUID articleId,
+    UUID readerId, // 알림을 받을 사람 (댓글 작성자)
+    String likerNickname // 좋아요를 누른 사람의 닉네임 (알림 문구용)
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/notification/listener/NotificationListener.java
+++ b/src/main/java/com/codeit/monew/domain/notification/listener/NotificationListener.java
@@ -1,0 +1,38 @@
+package com.codeit.monew.domain.notification.listener;
+
+import com.codeit.monew.domain.notification.event.BulkArticleRegisteredEvent;
+import com.codeit.monew.domain.notification.event.CommentLikedEvent;
+import com.codeit.monew.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationListener {
+  private final NotificationService notificationService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleBulkArticleScrapedEvent(BulkArticleRegisteredEvent event) {
+    log.info("[NOTIFICATION_LISTENER] 비동기 기사 알림 처리 시작: 관심사 수={}", event.interestCounts().size());
+
+    notificationService.createInterestNotifications(event);
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleCommentLikedEvent(CommentLikedEvent event) {
+    log.info("[NOTIFICATION_LISTENER] 비동기 댓글 좋아요 알림 처리 시작: commentId={}", event.commentId());
+
+    notificationService.createCommentLikeNotification(
+        event.commentId(),
+        event.readerId(),
+        event.likerNickname()
+    );
+  }
+}

--- a/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.monew.domain.notification.repository;
+
+import com.codeit.monew.domain.notification.entity.Notification;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+}

--- a/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
@@ -13,6 +13,7 @@ import com.codeit.monew.domain.user.repository.UserRepository;
 import com.codeit.monew.global.exception.comment.CommentNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -37,6 +38,20 @@ public class NotificationService {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void createInterestNotifications(BulkArticleRegisteredEvent event) {
     if (event.interestCounts() == null || event.interestCounts().isEmpty()) return;
+
+    // 이벤트 페이로드에 중복된 관심사 ID가 있더라도 개수를 합산하여 멱등성 보장
+    Map<UUID, BulkArticleRegisteredEvent.InterestArticleCount> mergedCountsMap = event.interestCounts().stream()
+        .collect(Collectors.toMap(
+            BulkArticleRegisteredEvent.InterestArticleCount::interestId,
+            countInfo -> countInfo,
+            // 중복된 ID가 발견되면, 이전 값과 현재 값의 기사 개수를 더해 새로운 객체 생성
+            (prev, curr) -> new BulkArticleRegisteredEvent.InterestArticleCount(
+                prev.interestId(),
+                prev.interestName(),
+                prev.articleCount() + curr.articleCount()
+            ),
+            LinkedHashMap::new // 순서 보장
+        ));
 
     // 1. 이벤트로 넘어온 관심사 ID 목록 추출
     List<UUID> targetInterestIds = event.interestCounts().stream()

--- a/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
@@ -95,6 +95,13 @@ public class NotificationService {
           return new CommentNotFoundException(commentId);
         });
 
+    // 2-1. 이벤트로 넘어온 readerId가 실제 댓글 작성자가 맞는지 교차 검증
+    if (comment.getUser() == null || !comment.getUser().getId().equals(reader.getId())) {
+      log.warn("[NOTIFICATION_SERVICE] 댓글 좋아요 알림 실패 - 수신자 불일치: commentId={}, readerId={}, commentOwnerId={}",
+          commentId, readerId, comment.getUser() == null ? null : comment.getUser().getId());
+      throw new IllegalStateException("댓글 작성자와 알림을 받을 사용자의 ID값이 일치하지 않습니다.");
+    }
+
     // 3. 알림 내용 생성
     String content = String.format("[%s]님이 나의 댓글을 좋아합니다.", likerNickname);
     CommentNotification notification = CommentNotification.create(reader, content, comment);

--- a/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
@@ -1,0 +1,106 @@
+package com.codeit.monew.domain.notification.service;
+
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.comment.repository.CommentRepository;
+import com.codeit.monew.domain.interest.entity.Subscription;
+import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
+import com.codeit.monew.domain.notification.entity.CommentNotification;
+import com.codeit.monew.domain.notification.entity.InterestNotification;
+import com.codeit.monew.domain.notification.event.BulkArticleRegisteredEvent;
+import com.codeit.monew.domain.notification.repository.NotificationRepository;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.exception.comment.CommentNotFoundException;
+import com.codeit.monew.global.exception.user.UserNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final SubscriptionRepository subscriptionRepository;
+  private final UserRepository userRepository;
+  private final CommentRepository commentRepository;
+
+  // 기사 등록 알림
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void createInterestNotifications(BulkArticleRegisteredEvent event) {
+    if (event.interestCounts() == null || event.interestCounts().isEmpty()) return;
+
+    // 1. 이벤트로 넘어온 관심사 ID 목록 추출
+    List<UUID> targetInterestIds = event.interestCounts().stream()
+        .map(BulkArticleRegisteredEvent.InterestArticleCount::interestId)
+        .toList();
+
+    // 2. 해당 관심사들의 구독 정보(유저, 관심사)를 한 번에 조회
+    List<Subscription> subscriptions = subscriptionRepository.findAllByInterestIdInWithUserAndInterest(targetInterestIds);
+    if (subscriptions.isEmpty()) return;
+
+    // 3. 구독자 리스트 - 관심사 ID를 key로 하는 Map으로 그룹핑
+    Map<UUID, List<Subscription>> subscriptionsByInterestId = subscriptions.stream()
+        .collect(Collectors.groupingBy(sub -> sub.getInterest().getId()));
+
+    List<InterestNotification> notificationsToSave = new ArrayList<>();
+
+    // 4. 알림 조립
+    for (BulkArticleRegisteredEvent.InterestArticleCount countInfo : event.interestCounts()) {
+
+      // 해당 관심사를 구독하는 목록 꺼내기 (없으면 빈 리스트 반환하여 NullPointerException 방어)
+      List<Subscription> matchedSubscriptions = subscriptionsByInterestId.getOrDefault(countInfo.interestId(), List.of());
+      if (matchedSubscriptions.isEmpty()) continue;
+
+      // 알림 문구 생성
+      String content = String.format("[%s]와 관련된 기사가 %d건 등록되었습니다.", countInfo.interestName(), countInfo.articleCount());
+
+      // 구독자 수만큼 엔티티 생성
+      for (Subscription sub : matchedSubscriptions) {
+        notificationsToSave.add(
+            InterestNotification.create(sub.getUser(), content, sub.getInterest())
+        );
+      }
+    }
+
+    // 5. 일괄 저장
+    if (!notificationsToSave.isEmpty()) {
+      notificationRepository.saveAll(notificationsToSave);
+      log.info("[NOTIFICATION_SERVICE] 관심사 기사 알림 대량 생성 완료: 총 {}건", notificationsToSave.size());
+    }
+  }
+
+  // 댓글 좋아요 알림
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void createCommentLikeNotification(UUID commentId, UUID readerId, String likerNickname) {
+    // 1. 알림을 받을 사람 (댓글 작성자) 조회
+    User reader = userRepository.findByIdAndDeletedAtIsNull(readerId)
+        .orElseThrow(() -> {
+          log.warn("[NOTIFICATION_SERVICE] 댓글 좋아요 알림 실패 - 유저 없음: readerId={}", readerId);
+          return new UserNotFoundException(readerId);
+        });
+
+    // 2. 대상 댓글 조회
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> {
+          log.warn("[NOTIFICATION_SERVICE] 댓글 좋아요 알림 실패 - 댓글 없음: commentId={}", commentId);
+          return new CommentNotFoundException(commentId);
+        });
+
+    // 3. 알림 내용 생성
+    String content = String.format("[%s]님이 나의 댓글을 좋아합니다.", likerNickname);
+    CommentNotification notification = CommentNotification.create(reader, content, comment);
+
+    // 4. 저장
+    notificationRepository.save(notification);
+    log.info("[NOTIFICATION_SERVICE] 댓글 좋아요 알림 생성 완료: notificationId={}", notification.getId());
+  }
+}

--- a/src/main/java/com/codeit/monew/global/config/AsyncConfig.java
+++ b/src/main/java/com/codeit/monew/global/config/AsyncConfig.java
@@ -1,0 +1,30 @@
+package com.codeit.monew.global.config;
+
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Slf4j
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(4); // 기본 스레드 수
+    executor.setMaxPoolSize(16); // 최대 스레드 수
+    executor.setQueueCapacity(500); // 대기열 큐 사이즈
+    executor.setThreadNamePrefix("async-"); // 로그에 찍힐 스레드 이름
+    executor.initialize();
+    return executor;
+  }
+
+  @Override
+  public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+    // 비동기 스레드에서 에러 시 로그
+    return (ex, method, params) ->
+        log.error("[ASYNC_ERROR] method={}, error={}", method.getName(), ex.getMessage(), ex);
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,189 @@
+package com.codeit.monew.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.monew.domain.comment.entity.Comment;
+import com.codeit.monew.domain.comment.repository.CommentRepository;
+import com.codeit.monew.domain.interest.entity.Interest;
+import com.codeit.monew.domain.notification.entity.CommentNotification;
+import com.codeit.monew.domain.notification.entity.InterestNotification;
+import com.codeit.monew.domain.notification.event.BulkArticleRegisteredEvent;
+import com.codeit.monew.domain.notification.repository.NotificationRepository;
+import com.codeit.monew.domain.interest.entity.Subscription;
+import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
+import com.codeit.monew.domain.user.entity.User;
+import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.exception.comment.CommentNotFoundException;
+import com.codeit.monew.global.exception.user.UserNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+  @InjectMocks
+  private NotificationService notificationService;
+
+  @Mock private NotificationRepository notificationRepository;
+  @Mock private SubscriptionRepository subscriptionRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private CommentRepository commentRepository;
+
+  @Captor
+  private ArgumentCaptor<List<InterestNotification>> interestNotificationListCaptor;
+  @Captor
+  private ArgumentCaptor<CommentNotification> commentNotificationCaptor;
+
+  @Nested
+  @DisplayName("기사 등록 알림 테스트")
+  class CreateInterestNotificationsTest {
+
+    @Test
+    @DisplayName("이벤트 데이터가 null이거나 비어있으면 조기 종료된다.")
+    void returnEarlyWhenEventDataIsNullOrEmpty() {
+      // given
+      BulkArticleRegisteredEvent emptyEvent = new BulkArticleRegisteredEvent(Collections.emptyList());
+
+      // when
+      notificationService.createInterestNotifications(emptyEvent);
+
+      // then
+      verify(subscriptionRepository, never()).findAllByInterestIdInWithUserAndInterest(anyList());
+      verify(notificationRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("구독자가 한 명도 없으면 조기 종료된다.")
+    void returnEarlyWhenNoSubscribersFound() {
+      // given
+      UUID interestId = UUID.randomUUID();
+      BulkArticleRegisteredEvent event = new BulkArticleRegisteredEvent(
+          List.of(new BulkArticleRegisteredEvent.InterestArticleCount(interestId, "테스트 관심사", 5))
+      );
+
+      given(subscriptionRepository.findAllByInterestIdInWithUserAndInterest(anyList()))
+          .willReturn(Collections.emptyList());
+
+      // when
+      notificationService.createInterestNotifications(event);
+
+      // then
+      verify(notificationRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("구독자가 존재하면 알림을 대량 생성하여 저장한다.")
+    void successfullyCreateAndSaveBulkNotifications() {
+      // given
+      UUID interestId1 = UUID.randomUUID();
+      UUID interestId2 = UUID.randomUUID(); // 구독자가 없는 관심사
+
+      BulkArticleRegisteredEvent event = new BulkArticleRegisteredEvent(List.of(
+          new BulkArticleRegisteredEvent.InterestArticleCount(interestId1, "테스트 관심사1", 5),
+          new BulkArticleRegisteredEvent.InterestArticleCount(interestId2, "테스트 관심사2", 2)
+      ));
+
+      Interest mockInterest = mock(Interest.class);
+      given(mockInterest.getId()).willReturn(interestId1);
+
+      User mockUser = mock(User.class);
+      Subscription mockSubscription = mock(Subscription.class);
+      given(mockSubscription.getInterest()).willReturn(mockInterest);
+      given(mockSubscription.getUser()).willReturn(mockUser);
+
+      // 테스트 관심사1에 대해서만 1명의 구독자가 있다고 가정
+      given(subscriptionRepository.findAllByInterestIdInWithUserAndInterest(anyList()))
+          .willReturn(List.of(mockSubscription));
+
+      // when
+      notificationService.createInterestNotifications(event);
+
+      // then
+      verify(notificationRepository, times(1)).saveAll(interestNotificationListCaptor.capture());
+
+      List<InterestNotification> savedNotifications = interestNotificationListCaptor.getValue();
+      assertThat(savedNotifications).hasSize(1);
+      assertThat(savedNotifications.get(0).getContent()).isEqualTo("[테스트 관심사1]와 관련된 기사가 5건 등록되었습니다.");
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 좋아요 알림 테스트")
+  class CreateCommentLikeNotificationTest {
+
+    @Test
+    @DisplayName("유저를 찾을 수 없으면 UserNotFoundException이 발생한다.")
+    void throwExceptionWhenUserNotFound() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID readerId = UUID.randomUUID();
+      given(userRepository.findByIdAndDeletedAtIsNull(readerId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> notificationService.createCommentLikeNotification(commentId, readerId, "테스트 닉네임"))
+          .isInstanceOf(UserNotFoundException.class);
+      verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("댓글을 찾을 수 없으면 CommentNotFoundException이 발생한다.")
+    void throwExceptionWhenCommentNotFound() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID readerId = UUID.randomUUID();
+      User mockUser = mock(User.class);
+
+      given(userRepository.findByIdAndDeletedAtIsNull(readerId)).willReturn(Optional.of(mockUser));
+      given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> notificationService.createCommentLikeNotification(commentId, readerId, "테스트 닉네임"))
+          .isInstanceOf(CommentNotFoundException.class);
+      verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("정상적으로 댓글 좋아요 알림을 생성하고 저장한다.")
+    void successfullyCreateAndSaveCommentNotification() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID readerId = UUID.randomUUID();
+      String likerNickname = "테스트 닉네임";
+
+      User mockUser = mock(User.class);
+      Comment mockComment = mock(Comment.class);
+
+      given(userRepository.findByIdAndDeletedAtIsNull(readerId)).willReturn(Optional.of(mockUser));
+      given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+      // when
+      notificationService.createCommentLikeNotification(commentId, readerId, likerNickname);
+
+      // then
+      verify(notificationRepository, times(1)).save(commentNotificationCaptor.capture());
+
+      CommentNotification savedNotification = commentNotificationCaptor.getValue();
+      assertThat(savedNotification.getContent()).isEqualTo("[테스트 닉네임]님이 나의 댓글을 좋아합니다.");
+      assertThat(savedNotification.getUser()).isEqualTo(mockUser);
+      assertThat(savedNotification.getComment()).isEqualTo(mockComment);
+    }
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/notification/service/NotificationServiceTest.java
@@ -58,12 +58,14 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("이벤트 데이터가 null이거나 비어있으면 조기 종료된다.")
-    void returnEarlyWhenEventDataIsNullOrEmpty() {
+    void fail_create_notification_event_is_null_or_empty() {
       // given
       BulkArticleRegisteredEvent emptyEvent = new BulkArticleRegisteredEvent(Collections.emptyList());
+      BulkArticleRegisteredEvent nullEvent = new BulkArticleRegisteredEvent(null);
 
       // when
       notificationService.createInterestNotifications(emptyEvent);
+      notificationService.createInterestNotifications(nullEvent);
 
       // then
       verify(subscriptionRepository, never()).findAllByInterestIdInWithUserAndInterest(anyList());
@@ -72,7 +74,7 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("구독자가 한 명도 없으면 조기 종료된다.")
-    void returnEarlyWhenNoSubscribersFound() {
+    void fail_create_notification_no_subscribers() {
       // given
       UUID interestId = UUID.randomUUID();
       BulkArticleRegisteredEvent event = new BulkArticleRegisteredEvent(
@@ -91,7 +93,7 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("구독자가 존재하면 알림을 대량 생성하여 저장한다.")
-    void successfullyCreateAndSaveBulkNotifications() {
+    void success_create_article_notifications() {
       // given
       UUID interestId1 = UUID.randomUUID();
       UUID interestId2 = UUID.randomUUID(); // 구독자가 없는 관심사
@@ -131,7 +133,7 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("유저를 찾을 수 없으면 UserNotFoundException이 발생한다.")
-    void throwExceptionWhenUserNotFound() {
+    void fail_create_notification_UserNotFound() {
       // given
       UUID commentId = UUID.randomUUID();
       UUID readerId = UUID.randomUUID();
@@ -145,7 +147,7 @@ class NotificationServiceTest {
 
     @Test
     @DisplayName("댓글을 찾을 수 없으면 CommentNotFoundException이 발생한다.")
-    void throwExceptionWhenCommentNotFound() {
+    void fail_create_notification_CommentNotFound() {
       // given
       UUID commentId = UUID.randomUUID();
       UUID readerId = UUID.randomUUID();
@@ -161,15 +163,46 @@ class NotificationServiceTest {
     }
 
     @Test
+    @DisplayName("댓글 작성자와 알림 수신자가 일치하지 않으면 IllegalStateException이 발생한다.")
+    void fail_create_notification_ReceiverMismatch() {
+      // given
+      UUID commentId = UUID.randomUUID();
+      UUID readerId = UUID.randomUUID();
+      UUID realOwnerId = UUID.randomUUID(); // 실제 작성자의 다른 ID
+
+      User mockReader = mock(User.class);
+      given(mockReader.getId()).willReturn(readerId); // 수신자 ID
+
+      User mockOwner = mock(User.class);
+      given(mockOwner.getId()).willReturn(realOwnerId); // 실제 작성자 ID
+
+      Comment mockComment = mock(Comment.class);
+      given(mockComment.getUser()).willReturn(mockOwner);
+
+      given(userRepository.findByIdAndDeletedAtIsNull(readerId)).willReturn(Optional.of(mockReader));
+      given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+      // when & then
+      assertThatThrownBy(() -> notificationService.createCommentLikeNotification(commentId, readerId, "테스트 닉네임"))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("댓글 작성자와 알림을 받을 사용자의 ID값이 일치하지 않습니다.");
+
+      verify(notificationRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("정상적으로 댓글 좋아요 알림을 생성하고 저장한다.")
-    void successfullyCreateAndSaveCommentNotification() {
+    void success_create_comment_notifications() {
       // given
       UUID commentId = UUID.randomUUID();
       UUID readerId = UUID.randomUUID();
       String likerNickname = "테스트 닉네임";
 
       User mockUser = mock(User.class);
+      given(mockUser.getId()).willReturn(readerId);
+
       Comment mockComment = mock(Comment.class);
+      given(mockComment.getUser()).willReturn(mockUser);
 
       given(userRepository.findByIdAndDeletedAtIsNull(readerId)).willReturn(Optional.of(mockUser));
       given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) Closes #36, #44, #41, #45

## 📝작업 내용

- 비동기 알림 처리를 위한 Event 및 Listener 구현
- 알림 Entity 구현
- 알림 Repository 인터페이스 추가
- 알림 생성 Service 로직 구현
- 알림 생성 응답 DTO 추가
- 알림 생성 단위 테스트 진행

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관심사 관련 기사 등록 시 구독자에게 알림이 생성됩니다.
  * 댓글에 좋아요가 달리면 해당 사용자에게 알림이 생성됩니다.
  * 알림은 비동기 백그라운드 처리로 빠르게 생성되고 확인(확인 처리) 기능이 추가되었습니다.

* **테스트**
  * 알림 생성 로직(대량 관심사 처리, 좋아요 알림)의 단위 테스트가 추가되어 주요 예외 및 정상 흐름을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->