### PR TITLE
[fix] 활동 내역 로직으로 인해 통과되지 못하던 서비스 테스트 코드 수정

### DIFF
--- a/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
@@ -354,7 +354,7 @@ class ArticleServiceTest {
   class view {
 
     @Test
-    @DisplayName("기존 조회 이력이 없을 경우 뉴스 기사 ID와 사용자 ID로 뉴스 기사 view를 등록할 수 있다.")
+    @DisplayName("기존 조회 이력이 없을 경우 뉴스 기사 ID와 사용자 ID로 뉴스 기사 view(RDB)를 등록할 수 있다.")
     void success_post_article_view_by_articleId_and_userId_when_view_not_exist() {
       // given(준비)
       UUID articleId = UUID.randomUUID();
@@ -397,7 +397,7 @@ class ArticleServiceTest {
     }
 
     @Test
-    @DisplayName("기존 조회 이력이 있을 경우 뉴스 기사 ID와 사용자 ID로 뉴스 기사 view를 등록할 수 있다.")
+    @DisplayName("기존 조회 이력이 있을 경우 뉴스 기사 ID와 사용자 ID로 뉴스 기사 view(RDB)를 등록할 수 있다.")
     void success_post_article_view_by_articleId_and_userId_when_view_already_exist() {
       // given(준비)
       UUID articleId = UUID.randomUUID();

--- a/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/service/ArticleServiceTest.java
@@ -27,6 +27,8 @@ import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.repository.InterestRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.event.ArticleViewedEvent;
+import com.codeit.monew.global.event.UserRegisteredEvent;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.Interest.InterestNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
@@ -42,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +70,9 @@ class ArticleServiceTest {
 
   @Mock
   private ArticleViewMapper articleViewMapper;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private ArticleService articleService;
@@ -387,6 +393,7 @@ class ArticleServiceTest {
       verify(commentRepository).countByArticleIdAndDeletedAtIsNull(articleId);
       verify(articleViewHistoryRepository).countByArticleId(articleId);
       verify(articleViewMapper).toDto(articleViewHistory, article, user, 3, 5);
+      verify(eventPublisher).publishEvent(any(ArticleViewedEvent.class));
     }
 
     @Test
@@ -426,6 +433,7 @@ class ArticleServiceTest {
       verify(commentRepository).countByArticleIdAndDeletedAtIsNull(articleId);
       verify(articleViewHistoryRepository).countByArticleId(articleId);
       verify(articleViewMapper).toDto(articleViewHistory, article, user, 3, 5);
+      verify(eventPublisher).publishEvent(any(ArticleViewedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/codeit/monew/domain/comment/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/service/CommentLikeServiceTest.java
@@ -16,6 +16,9 @@ import com.codeit.monew.domain.comment.repository.CommentLikeRepository;
 import com.codeit.monew.domain.comment.repository.CommentRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.event.ArticleViewedEvent;
+import com.codeit.monew.global.event.CommentLikedCancelEvent;
+import com.codeit.monew.global.event.CommentLikedEvent;
 import com.codeit.monew.global.exception.comment.CommentLikeAlreadyExistsException;
 import com.codeit.monew.global.exception.comment.CommentLikeNotFoundException;
 import com.codeit.monew.global.exception.comment.CommentNotFoundException;
@@ -31,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -41,6 +45,7 @@ class CommentLikeServiceTest {
   @Mock private CommentLikeRepository commentLikeRepository;
   @Mock private CommentRepository commentRepository;
   @Mock private UserRepository userRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   private UUID userId;
   private UUID commentId;
@@ -89,6 +94,7 @@ class CommentLikeServiceTest {
       // then
       verify(comment).increaseLikeCount(); // 낙관적 락 발동 메서드 호출 검증
       verify(commentLikeRepository).save(any(CommentLike.class)); // 저장 검증
+      verify(eventPublisher).publishEvent(any(CommentLikedEvent.class));
       assertThat(result.commentId()).isEqualTo(commentId);
       assertThat(result.likedBy()).isEqualTo(userId);
     }
@@ -136,6 +142,7 @@ class CommentLikeServiceTest {
       // then
       verify(comment).decreaseLikeCount(); // 감소 메서드 호출 검증
       verify(commentLikeRepository).deleteByCommentIdAndUserId(commentId, userId); // 삭제 쿼리 검증
+      verify(eventPublisher).publishEvent(any(CommentLikedCancelEvent.class));
     }
 
     @Test

--- a/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/comment/service/CommentServiceTest.java
@@ -12,6 +12,9 @@ import com.codeit.monew.domain.comment.repository.CommentQueryRepository;
 import com.codeit.monew.domain.comment.repository.CommentRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.event.CommentCreatedEvent;
+import com.codeit.monew.global.event.CommentLikedEvent;
+import com.codeit.monew.global.event.CommentUpdatedEvent;
 import com.codeit.monew.global.exception.article.ArticleNotFoundException;
 import com.codeit.monew.global.exception.user.UserNotFoundException;
 
@@ -28,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,6 +57,7 @@ class CommentServiceTest {
   @Mock private UserRepository userRepository;
   @Mock private CommentQueryRepository commentQueryRepository;
   @Mock private CommentMapper commentMapper;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @Nested
   @DisplayName("댓글 등록 테스트")
@@ -92,6 +97,7 @@ class CommentServiceTest {
 
       // DB에 save 메서드가 1번 호출되었는지 검증
       verify(commentRepository).save(any(Comment.class));
+      verify(eventPublisher).publishEvent(any(CommentCreatedEvent.class));
     }
 
     @Test
@@ -170,6 +176,7 @@ class CommentServiceTest {
       assertThat(result.content()).isEqualTo(newContent);
       assertThat(comment.getContent()).isEqualTo(newContent); // 엔티티 내부 상태가 변했는지 검증
       verify(commentLikeRepository).existsByCommentIdAndUserId(commentId, userId); // 좋아요 레포지토리가 정상적으로 호출되었는지 검증
+      verify(eventPublisher).publishEvent(any(CommentUpdatedEvent.class));
     }
 
     @Test

--- a/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/codeit/monew/domain/interest/service/InterestServiceTest.java
@@ -20,6 +20,9 @@ import com.codeit.monew.domain.interest.repository.KeywordRepository;
 import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.global.event.CommentLikedEvent;
+import com.codeit.monew.global.event.InterestSubscribedEvent;
+import com.codeit.monew.global.event.InterestUnSubscribedEvent;
 import com.codeit.monew.global.exception.Interest.AlreadySubscribedException;
 import com.codeit.monew.global.exception.Interest.DuplicateInterestException;
 import com.codeit.monew.global.exception.Interest.InterestNotFoundException;
@@ -35,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -49,6 +53,8 @@ class InterestServiceTest {
   private SubscriptionRepository subscriptionRepository;
   @Mock
   private UserRepository userRepository;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private InterestService interestService;
@@ -277,6 +283,7 @@ class InterestServiceTest {
       assertEquals(interestId, result.interestId());
       verify(subscriptionRepository).save(any());
       verify(interestRepository).incrementSubscriberCount(interestId);
+      verify(eventPublisher).publishEvent(any(InterestSubscribedEvent.class));
     }
 
     @Test
@@ -341,6 +348,7 @@ class InterestServiceTest {
       // then
       verify(subscriptionRepository).deleteByUserIdAndInterestId(userId, interestId);
       verify(interestRepository).decrementSubscriberCount(interestId);
+      verify(eventPublisher).publishEvent(any(InterestUnSubscribedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용

기존 서비스 코드에 활동 내역 갱신을 위한 ApplicationEventPublisher가 추가되어 실패되던 테스트 케이스들을 통과되도록 수정하였습니다.
- ArticleService
  - view()
- CommentService
  - registerComment()
  - updateComment()
- CommentLikeService
  - addLike()
  - cancelLike()
- InterestService
  - subscribe()
  - unsubscribe()
- UserService - (이전에 수정)
  - register()

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

현재는 verify(eventPublisher).publishEvent(any(Event.class)); 의 형태로 이벤트 발행이 수행 되었는지만 테스트하고 있는데,
추후 필요하다면 ArgumentCaptor로 발행된 이벤트 값 검증 로직도 추가하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* 문서 조회, 댓글 생성/수정, 댓글 좋아요/취소, 관심사 구독/구독 취소 등 주요 서비스 동작에서 애플리케이션 이벤트의 발행 여부를 검증하도록 테스트를 강화했습니다. 테스트 설명을 보다 명확히 하고 관련 이벤트 발행 검증을 추가해 동작 신뢰성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->