### PR TITLE
[fix] 알림 목록 화면이 뜨지 않는 오류 수정

### DIFF
--- a/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
@@ -60,7 +60,9 @@ public class Notification extends BaseUpdatableEntity {
 
   // 비즈니스 로직 - 알림 읽음 처리
   public void confirm() {
-    this.confirmedAt = Instant.now();
+    if (this.confirmedAt == null) {
+      this.confirmedAt = Instant.now();
+    }
   }
 
   // 알림 확인 여부 반환

--- a/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
@@ -12,13 +12,14 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "notifications", indexes = {
-    @Index(name = "idx_notification_user_confirmed_created", columnList = "user_id, confirmed, created_at DESC")
+    @Index(name = "idx_notification_user_confirmed_created", columnList = "user_id, confirmed_at, created_at DESC")
 })
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE) // resource 필드에 기사/댓글 모두 할당 가능하게 하기 위해 자식 클래스 생성
 @DiscriminatorColumn(name = "resource_type") // 자원 타입
@@ -35,16 +36,16 @@ public class Notification extends BaseUpdatableEntity {
   @Column(name = "content", nullable = false, length = 500)
   private String content;
 
-  // 알림 확인 여부
-  @Column(name = "confirmed", nullable = false)
-  private boolean confirmed = false;
+  // 알림 확인 시각
+  @Column(name = "confirmed_at")
+  private Instant confirmedAt;
 
   // 자식 클래스에서 호출할 생성자
   protected Notification(User user, String content) {
     validateNotification(user, content); // 생성 시 내부 검증 로직 실행
     this.user = user;
     this.content = content;
-    this.confirmed = false;
+    this.confirmedAt = null;
   }
 
   // 엔티티 무결성 검증 로직
@@ -59,6 +60,11 @@ public class Notification extends BaseUpdatableEntity {
 
   // 비즈니스 로직 - 알림 읽음 처리
   public void confirm() {
-    this.confirmed = true;
+    this.confirmedAt = Instant.now();
+  }
+
+  // 알림 확인 여부 반환
+  public boolean isConfirmed() {
+    return this.confirmedAt != null;
   }
 }

--- a/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
@@ -18,7 +18,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   // 알림 일괄 삭제용
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM Notification n " +
-      "WHERE n.confirmedAt IS NOT NULL " +
-      "AND n.createdAt < :targetTime")
+      "WHERE n.confirmedAt < :targetTime")
   int deleteOldConfirmedNotifications(@Param("targetTime") Instant targetTime);
 }

--- a/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
@@ -12,13 +12,13 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   // 알림 전체 읽음 처리용
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE Notification n SET n.confirmed = true WHERE n.user.id = :userId AND n.confirmed = false")
+  @Query("UPDATE Notification n SET n.confirmedAt = CURRENT_TIMESTAMP WHERE n.user.id = :userId AND n.confirmedAt IS NULL")
   int confirmAllByUserId(@Param("userId") UUID userId);
 
   // 알림 일괄 삭제용
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM Notification n " +
-      "WHERE n.confirmed = true " +
+      "WHERE n.confirmedAt IS NOT NULL " +
       "AND n.createdAt < :targetTime")
   int deleteOldConfirmedNotifications(@Param("targetTime") Instant targetTime);
 }

--- a/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/monew/domain/notification/repository/NotificationRepository.java
@@ -12,8 +12,8 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   // 알림 전체 읽음 처리용
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE Notification n SET n.confirmedAt = CURRENT_TIMESTAMP WHERE n.user.id = :userId AND n.confirmedAt IS NULL")
-  int confirmAllByUserId(@Param("userId") UUID userId);
+  @Query("UPDATE Notification n SET n.confirmedAt = :now WHERE n.user.id = :userId AND n.confirmedAt IS NULL")
+  int confirmAllByUserId(@Param("userId") UUID userId, @Param("now") Instant now);
 
   // 알림 일괄 삭제용
   @Modifying(clearAutomatically = true)

--- a/src/main/java/com/codeit/monew/domain/notification/repository/impl/NotificationQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/monew/domain/notification/repository/impl/NotificationQueryRepositoryImpl.java
@@ -24,7 +24,7 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
         .selectFrom(notification)
         .where(
             notification.user.id.eq(userId), // 해당 유저의 알림
-            notification.confirmed.isFalse(), // 미확인 알림
+            notification.confirmedAt.isNull(), // 미확인 알림
             ltCursor(after, cursor) // 커서 페이징 조건 (이전 페이지의 마지막 데이터 다음부터)
         )
         .orderBy(notification.createdAt.desc(), notification.id.desc()) // 최신 알람부터 보이도록 정렬
@@ -39,7 +39,7 @@ public class NotificationQueryRepositoryImpl implements NotificationQueryReposit
     Long count = queryFactory
         .select(notification.count()) // 미확인 알림 개수
         .from(notification) // 해당 유저의 알림
-        .where(notification.user.id.eq(userId), notification.confirmed.isFalse()) // 미확인 알림
+        .where(notification.user.id.eq(userId), notification.confirmedAt.isNull()) // 미확인 알림
         .fetchOne();
 
     return count != null ? count : 0L;

--- a/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
@@ -157,7 +157,7 @@ public class NotificationService {
   // 전체 알림 확인
   @Transactional
   public void confirmAllNotifications(UUID userId) {
-    int updatedCount = notificationRepository.confirmAllByUserId(userId);
+    int updatedCount = notificationRepository.confirmAllByUserId(userId, Instant.now());
     log.info("[NOTIFICATION_CONFIRM] 유저 {}의 알림 {}건 전체 읽음 처리 완료", userId, updatedCount);
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #149

## 📝작업 내용

알림 읽음 처리 필드를 DB 스키마에 맞게 `confirmedAt`으로 수정하였습니다.
- 알림 Entity
  - `boolean confirmed` 필드를 `Instant confirmedAt`으로 변경
- 알림 Repository 동기화
  - QueryDSL: 미확인 알림 조회 조건을 `confirmedAt.isNull()`로 수정
  - 전체 읽음 처리: `confirmedAt` 필드에 현재 시간을 업데이트하도록 쿼리 수정
  - 알림 일괄 삭제: `confirmedAt` 필드 값이 존재하는 경우에만 알림을 삭제할 수 있도록 쿼리 수정
 
## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 알림의 확인 상태가 불리언에서 확인 시각(타임스탬프)으로 변경되어 언제 확인되었는지 기록합니다.
  * 최초 확인 시각만 저장되어 중복 갱신을 방지합니다.
  * 미확인 목록 조회, 일괄 확인 처리 및 오래된 확인된 알림 삭제가 확인 시각을 기준으로 동작하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->