### PR TITLE
[fix] 활동 내역 조회 성능 병목 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ dependencies {
 
     // Levenshtein Distance(유사도 검증 알고리즘)
     implementation 'org.apache.commons:commons-text:1.11.0'
+
+    // 스프링 캐시 추상화 라이브러리 (CacheManager, @Cacheable 등 제공)
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // Caffeine Cache 구현체 라이브러리
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/monew/MonewApplication.java
+++ b/src/main/java/com/codeit/monew/MonewApplication.java
@@ -4,6 +4,7 @@ import com.codeit.monew.global.config.AwsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -13,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableAsync
 @EnableRetry
+@EnableCaching
 public class MonewApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
@@ -42,10 +42,12 @@ public class UserActivityEventListener {
   // DB 업데이트 이후 이전 캐시를 삭제하는 헬퍼 메서드
   private void evictUserActivityCache(UUID userId) {
     Cache cache = cacheManager.getCache("userActivity");
-    if (cache != null) {
-      cache.evict(userId); // @Cacheable의 key가 UUID이므로 그대로 전달
-      log.debug("[USER_ACTIVITY_CACHE] 캐시 안전 삭제 완료: userId={}", userId);
+    if (cache == null) {
+      log.warn("[USER_ACTIVITY_CACHE] 캐시를 찾지 못해 삭제 스킵: userId={}", userId);
+      return;
     }
+    cache.evict(userId); // @Cacheable의 key가 UUID이므로 그대로 전달
+    log.debug("[USER_ACTIVITY_CACHE] 캐시 안전 삭제 완료: userId={}", userId);
   }
 
   // 타인들의 ID를 찾아서 캐시를 지우는 헬퍼 메서드

--- a/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
@@ -14,9 +14,13 @@ import com.codeit.monew.domain.useractivity.event.InterestSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestUnSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.UserRegisteredEvent;
 import com.codeit.monew.domain.useractivity.mapper.UserActivityMapper;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -33,6 +37,29 @@ public class UserActivityEventListener {
 
   private final MongoTemplate mongoTemplate;
   private final UserActivityMapper userActivityMapper;
+  private final CacheManager cacheManager;
+
+  // DB 업데이트 이후 이전 캐시를 삭제하는 헬퍼 메서드
+  private void evictUserActivityCache(UUID userId) {
+    Cache cache = cacheManager.getCache("userActivity");
+    if (cache != null) {
+      cache.evict(userId); // @Cacheable의 key가 UUID이므로 그대로 전달
+      log.debug("[USER_ACTIVITY_CACHE] 캐시 안전 삭제 완료: userId={}", userId);
+    }
+  }
+
+  // 타인들의 ID를 찾아서 캐시를 지우는 헬퍼 메서드
+  private void queryForLikedUsers(UUID commentId) {
+    Query query = new Query(Criteria.where("commentLikes.commentId").is(commentId.toString()));
+    query.fields().include("_id");
+
+    List<UserActivity> likedUsers = mongoTemplate.find(query, UserActivity.class);
+
+    for (UserActivity user : likedUsers) {
+      // 찾아낸 모든 타인의 캐시를 지워서 다음 조회 시 최신 데이터를 보게 함
+      evictUserActivityCache(UUID.fromString(user.getId()));
+    }
+  }
 
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -48,6 +75,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.upsert(query, update, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 새로운 유저 도큐먼트 생성 완료");
   }
 
@@ -69,6 +97,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.upsert(query, update, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 관심사 구독 목록 업데이트 완료");
   }
 
@@ -86,6 +115,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.updateFirst(query, pullUpdate, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 관심사 구독 취소 완료");
   }
 
@@ -107,6 +137,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.upsert(query, update, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 댓글 목록 업데이트 완료");
   }
 
@@ -120,19 +151,20 @@ public class UserActivityEventListener {
         Criteria.where("_id").is(event.userId().toString())
             .and("comments.id").is(event.commentId().toString())
     );
-
     // 댓글 수정
     Update commentUpdate = new Update().set("comments.$.content", event.newContent());
     mongoTemplate.updateFirst(commentQuery, commentUpdate, UserActivity.class);
 
-    Query likeQuery = new Query(
-        Criteria.where("commentLikes.commentId").is(event.commentId().toString())
-    );
-
     // 댓글 좋아요 활동 내역에도 모두 반영
+    Query likeQuery = new Query(Criteria.where("commentLikes.commentId").is(event.commentId().toString()));
     Update likeUpdate = new Update().set("commentLikes.$.commentContent", event.newContent());
-
     mongoTemplate.updateMulti(likeQuery, likeUpdate, UserActivity.class);
+
+    // 작성자 본인 캐시 삭제
+    evictUserActivityCache(event.userId());
+
+    // 좋아요 누른 사람들 캐시 삭제
+    queryForLikedUsers(event.commentId());
 
     log.info("[USER_ACTIVITY] 댓글 내용 수정 완료");
   }
@@ -155,6 +187,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.upsert(query, update, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 댓글 좋아요 목록 업데이트 완료");
   }
 
@@ -171,6 +204,7 @@ public class UserActivityEventListener {
 
     mongoTemplate.updateFirst(query, pullUpdate, UserActivity.class);
 
+    evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 댓글 좋아요 취소 완료");
   }
 
@@ -198,9 +232,8 @@ public class UserActivityEventListener {
         .each(newArticleViewInfo);
 
     mongoTemplate.upsert(query, pushUpdate, UserActivity.class);
-
+    evictUserActivityCache(event.viewedBy());
     log.info("[USER_ACTIVITY] 기사 조회 목록 업데이트 완료");
   }
-
 
 }

--- a/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
@@ -56,8 +56,12 @@ public class UserActivityEventListener {
     List<UserActivity> likedUsers = mongoTemplate.find(query, UserActivity.class);
 
     for (UserActivity user : likedUsers) {
-      // 찾아낸 모든 타인의 캐시를 지워서 다음 조회 시 최신 데이터를 보게 함
-      evictUserActivityCache(UUID.fromString(user.getId()));
+      try {
+        // 찾아낸 모든 타인의 캐시를 지워서 다음 조회 시 최신 데이터를 보게 함
+        evictUserActivityCache(UUID.fromString(user.getId()));
+      } catch (IllegalArgumentException e) {
+        log.warn("[USER_ACTIVITY_CACHE] 잘못된 userId 형식으로 캐시 삭제 스킵: id={}", user.getId());
+      }
     }
   }
 
@@ -154,17 +158,20 @@ public class UserActivityEventListener {
     // 댓글 수정
     Update commentUpdate = new Update().set("comments.$.content", event.newContent());
     mongoTemplate.updateFirst(commentQuery, commentUpdate, UserActivity.class);
-
-    // 댓글 좋아요 활동 내역에도 모두 반영
-    Query likeQuery = new Query(Criteria.where("commentLikes.commentId").is(event.commentId().toString()));
-    Update likeUpdate = new Update().set("commentLikes.$.commentContent", event.newContent());
-    mongoTemplate.updateMulti(likeQuery, likeUpdate, UserActivity.class);
-
     // 작성자 본인 캐시 삭제
     evictUserActivityCache(event.userId());
 
-    // 좋아요 누른 사람들 캐시 삭제
-    queryForLikedUsers(event.commentId());
+    // 댓글 좋아요 활동 내역에도 모두 반영
+    Query likeQuery = new Query(
+        Criteria.where("commentLikes.commentId").is(event.commentId().toString()));
+    Update likeUpdate = new Update().set("commentLikes.$.commentContent", event.newContent());
+
+    try {
+      mongoTemplate.updateMulti(likeQuery, likeUpdate, UserActivity.class);
+    } finally {
+      // 실패 경로에서도 보수적으로 무효화
+      queryForLikedUsers(event.commentId());
+    }
 
     log.info("[USER_ACTIVITY] 댓글 내용 수정 완료");
   }

--- a/src/main/java/com/codeit/monew/domain/useractivity/service/UserActivityService.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/service/UserActivityService.java
@@ -8,6 +8,7 @@ import com.codeit.monew.global.exception.user.UserNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +21,7 @@ public class UserActivityService {
 
   private final UserActivityMapper userActivityMapper;
 
-  @Transactional(readOnly = true)
+  @Cacheable(cacheNames = "userActivity", key = "#userId")
   public UserActivityDto getUserActivity(UUID userId) {
     UserActivity userActivity = userActivityRepository.findById(userId.toString())
         .orElseThrow(() -> new UserNotFoundException(userId));

--- a/src/main/java/com/codeit/monew/global/config/CacheConfig.java
+++ b/src/main/java/com/codeit/monew/global/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.codeit.monew.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+    cacheManager.setCaffeine(Caffeine.newBuilder()
+        .maximumSize(1000)
+        .expireAfterWrite(Duration.ofMinutes(10))
+    );
+    cacheManager.setCacheNames(List.of("userActivity"));
+    return cacheManager;
+  }
+}

--- a/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
@@ -7,8 +7,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.article.ArticleSource;
+import com.codeit.monew.domain.useractivity.entity.UserActivity;
 import com.codeit.monew.domain.useractivity.entity.UserActivity.ArticleViewInfo;
-import com.codeit.monew.domain.useractivity.entity.UserActivity.SubscriptionInfo;
 import com.codeit.monew.domain.useractivity.event.ArticleViewedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentCreatedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentLikedCancelEvent;
@@ -17,11 +17,10 @@ import com.codeit.monew.domain.useractivity.event.CommentUpdatedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestUnSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.UserRegisteredEvent;
+import com.codeit.monew.domain.useractivity.mapper.UserActivityMapper;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import com.codeit.monew.domain.useractivity.entity.UserActivity;
-import com.codeit.monew.domain.useractivity.mapper.UserActivityMapper;
 import org.bson.Document;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +30,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -45,6 +46,12 @@ class UserActivityEventListenerTest {
 
   @Mock
   private UserActivityMapper userActivityMapper;
+
+  @Mock
+  private CacheManager cacheManager;
+
+  @Mock
+  private Cache cache;
 
   @InjectMocks
   private UserActivityEventListener userActivityEventListener;
@@ -73,12 +80,14 @@ class UserActivityEventListenerTest {
         .set("email", event.email())
         .set("nickname", event.nickname())
         .set("createdAt", event.createdAt());
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleUserRegisteredEvent(event);
 
     // then
     verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
   }
@@ -108,6 +117,7 @@ class UserActivityEventListenerTest {
         .each(mockSubscriptionInfo);
 
     given(userActivityMapper.toSubscriptionInfo(any())).willReturn(mockSubscriptionInfo);
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
 
     // when
     userActivityEventListener.handleInterestSubscribedEvent(event);
@@ -115,6 +125,7 @@ class UserActivityEventListenerTest {
     // then
     verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
@@ -134,12 +145,14 @@ class UserActivityEventListenerTest {
     Update expectedUpdate = new Update().pull("subscriptions",
         new Document("interestId", event.interestId().toString())
     );
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleInterestUnSubscribedEvent(event);
 
     // then
     verify(mongoTemplate).updateFirst(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
@@ -173,16 +186,17 @@ class UserActivityEventListenerTest {
         .each(mockCommentInfo);
 
     given(userActivityMapper.toCommentInfo(any())).willReturn(mockCommentInfo);
-
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleCommentCreatedEvent(event);
 
     // then
     verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
-
+    verify(cache).evict(userId);
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
+
   }
 
   @Test
@@ -208,7 +222,7 @@ class UserActivityEventListenerTest {
     );
     Update expectedLikeUpdate = new Update().set("commentLikes.$.commentContent",
         event.newContent());
-
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleCommentUpdatedEvent(event);
 
@@ -217,6 +231,7 @@ class UserActivityEventListenerTest {
         eq(UserActivity.class));
     verify(mongoTemplate).updateMulti(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
 
     assertThat(queryCaptor.getAllValues().get(0)).isEqualTo(expectedCommentQuery);
     assertThat(updateCaptor.getAllValues().get(0)).isEqualTo(expectedCommentUpdate);
@@ -255,13 +270,14 @@ class UserActivityEventListenerTest {
         .each(mockCommentLikeInfo);
 
     given(userActivityMapper.toCommentLikeInfo(any())).willReturn(mockCommentLikeInfo);
-
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleCommentLikedEvent(event);
 
     // then
     verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
@@ -282,13 +298,14 @@ class UserActivityEventListenerTest {
     Update expectedUpdate = new Update().pull("commentLikes",
         new Document("commentId", event.commentId().toString())
     );
-
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleCommentLikedCancelEvent(event);
 
     // then
     verify(mongoTemplate).updateFirst(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(userId);
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
@@ -327,7 +344,7 @@ class UserActivityEventListenerTest {
         .each(mockArticleViewInfo);
 
     given(userActivityMapper.toArticleViewInfo(any())).willReturn(mockArticleViewInfo);
-
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
     // when
     userActivityEventListener.handleArticleViewedEvent(event);
 
@@ -336,6 +353,7 @@ class UserActivityEventListenerTest {
         eq(UserActivity.class));
     verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(),
         eq(UserActivity.class));
+    verify(cache).evict(event.viewedBy());
 
     assertThat(queryCaptor.getAllValues().get(0)).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getAllValues().get(0)).isEqualTo(expectedPullUpdate);


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) Closes #154

## 📝작업 내용

- 활동 내역 조회 시 캐싱을 추가했습니다.
  - UserActivityService를 통해 조회 시 캐싱이 적용됩니다.
  - UserActivityEventListener를 통해 데이터가 변경될 시 기존 캐시가 삭제 됩니다.

- 부하 테스트 결과 성능이 월등히 개선됨을 확인했습니다.
  - 평균 응답 시간 1.28ms (기존 692ms)
  - p95 응답 시간(기준 500) 2.24ms (기존 1.91s)
  - p99 응답 시간(기준 1000) 4ms (기존 1.95s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 활동 정보에 대한 캐시가 도입되어 응답 속도 및 효율이 향상됩니다.
* **동작 변경**
  * 사용자 등록, 관심사 구독/취소, 댓글 생성/좋아요, 기사 조회 등 주요 작업 시 관련 사용자 활동 캐시가 자동으로 무효화됩니다.
* **설정/빌드**
  * 애플리케이션 수준에서 캐시 지원이 활성화되고 캐시 구현(로컬 캐시, 만료 및 용량 제한 적용)이 추가되었습니다.
* **테스트**
  * 캐시 무효화 동작을 검증하는 테스트가 추가/보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->