### PR TITLE
[fix] 알림 조회 및 좋아요 알림 생성 누락 오류 수정

### DIFF
--- a/src/main/java/com/codeit/monew/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/codeit/monew/domain/comment/service/CommentLikeService.java
@@ -71,6 +71,14 @@ public class CommentLikeService {
           comment.getCreatedAt()
       ));
 
+      // 알림 생성을 위한 이벤트 발행
+      eventPublisher.publishEvent(new com.codeit.monew.domain.notification.event.CommentLikedEvent(
+          comment.getId(),
+          comment.getArticle().getId(),
+          comment.getUser().getId(),
+          user.getNickname()
+      ));
+
       return new CommentLikeDto(
           savedLike.getId(),
           user.getId(),

--- a/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
+++ b/src/main/java/com/codeit/monew/domain/notification/entity/Notification.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,6 +40,12 @@ public class Notification extends BaseUpdatableEntity {
   // 알림 확인 시각
   @Column(name = "confirmed_at")
   private Instant confirmedAt;
+
+  // 알림 대상 자원 ID
+  // 현재 코드에서는 자식 클래스에서 각각의 자원 ID(comment_id, interest_id)를 별도로 관리하지만,
+  // DB 상 resource_id의 NOT NULL 제약 조건을 방어하기 위해 랜덤 UUID값 할당
+  @Column(name = "resource_id", nullable = false)
+  private UUID resourceId = UUID.randomUUID();
 
   // 자식 클래스에서 호출할 생성자
   protected Notification(User user, String content) {

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -181,6 +183,22 @@ public class GlobalExceptionHandler {
     log.warn("[EXCEPTION] JSON 역직렬화 실패: message={}", e.getMessage());
     ErrorResponse errorResponse = new ErrorResponse(e, HttpStatus.BAD_REQUEST.value());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
+
+  @ExceptionHandler({InvalidDataAccessResourceUsageException.class, DataAccessException.class})
+  public ResponseEntity<ErrorResponse> handleDataAccessException(DataAccessException e) {
+    log.error("[EXCEPTION] 데이터베이스 오류: {}", e.getMessage());
+
+    ErrorResponse errorResponse = new ErrorResponse(
+        Instant.now(),
+        "DATABASE_ERROR",
+        "서버 내부 데이터베이스 오류가 발생했습니다.",
+        new HashMap<>(), // 쿼리 정보가 노출되면 안 되므로 빈 Map 전달
+        e.getClass().getSimpleName(),
+        HttpStatus.INTERNAL_SERVER_ERROR.value()
+    );
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
   }
 
   private HttpStatus determineHttpStatus(MonewException exception) {

--- a/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/monew/global/exception/GlobalExceptionHandler.java
@@ -187,7 +187,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler({InvalidDataAccessResourceUsageException.class, DataAccessException.class})
   public ResponseEntity<ErrorResponse> handleDataAccessException(DataAccessException e) {
-    log.error("[EXCEPTION] 데이터베이스 오류: {}", e.getMessage());
+    log.error("[EXCEPTION] 데이터베이스 오류: exceptionType={}", e.getClass().getSimpleName());
 
     ErrorResponse errorResponse = new ErrorResponse(
         Instant.now(),


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #153, #157

## 📝작업 내용

- 운영 환경 알림 조회 오류 관련
  - 운영 DB에 관련 컬럼을 반영하여 해결하였습니다.

- 예외 처리 개선
  - 데이터베이스 예외 발생 시 클라이언트 응답에 내부 쿼리 정보가 노출되지 않도록 전역 예외 처리 로직을 개선하였습니다.

- 알림 생성 오류 수정
  - `CommentLikeService` 내 댓글 좋아요 등록 시 누락된 이벤트 발행 로직을 추가하였습니다.
  - `Notification` 엔티티 구조 변경(단일 테이블 전략) 이후, 기존 DB 스키마에 남아있는 `resource_id` 컬럼의 NOT NULL 제약 조건을 방어하기 위해 임의의 UUID를 주입하는 필드(`resourceId`)를 추가하였습니다.

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 좋아요를 하면 추가적인 알림 이벤트가 발행되어 관련 사용자에게 알림이 더 정확히 전달됩니다.

* **개선 사항**
  * 알림 데이터에 고유 식별자가 포함되어 알림 추적 및 관리가 향상되었습니다.
  * 데이터베이스 관련 예외 처리 로직이 강화되어 내부 오류 발생 시 일관된 오류 응답(500)으로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->