### PR TITLE
[feat] 스케줄링 작업 커스텀 메트릭 추가 및 로컬 환경 대시보드 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     // Spring Boot Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // 수집된 메트릭을 Prometheus 포맷으로 변환
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // XML 파싱용 ROME
     implementation 'com.rometools:rome:2.1.0'
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,6 +78,38 @@ services:
     networks:
       - monew-network
 
+  # ---------------------------------------------------------
+  # [Prometheus 컨테이너]
+  # Spring 앱의 /actuator/prometheus 경로에서 주기적으로 지표 수집
+  # ---------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: monew-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # 도커 컨테이너가 호스트 OS를 인식할 수 있도록 설정
+    networks:
+      - monew-network
+
+  # ---------------------------------------------------------
+  # [Grafana 컨테이너]
+  # 수집된 시계열 데이터를 시각화하는 대시보드 제공
+  # ---------------------------------------------------------
+  grafana:
+    image: grafana/grafana:latest
+    container_name: monew-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - monew-network
+    depends_on:
+      - prometheus
+
 volumes:
   monew-postgres-data: # RDS로 전환 시 볼륨도 필요없으므로 주석 처리 또는 삭제하세요.
   monew-mongodb-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+    volumes:
+      - monew-grafana-data:/var/lib/grafana
     networks:
       - monew-network
     depends_on:
@@ -114,6 +116,7 @@ volumes:
   monew-postgres-data: # RDS로 전환 시 볼륨도 필요없으므로 주석 처리 또는 삭제하세요.
   monew-mongodb-data:
   monew-mongodb-config:
+  monew-grafana-data:
 
 networks:
   monew-network:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+  - job_name: 'monew-spring-app-local'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s # 테스트용으로 10초마다 수집
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/src/main/java/com/codeit/monew/MonewApplication.java
+++ b/src/main/java/com/codeit/monew/MonewApplication.java
@@ -20,5 +20,4 @@ public class MonewApplication {
   public static void main(String[] args) {
     SpringApplication.run(MonewApplication.class, args);
   }
-
 }

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
@@ -64,6 +64,10 @@ public class NaverArticleBatchJob {
       log.error("[NAVER_BATCH] keyword='{}' unexpected error", keyword, e);
       throw e;
     } finally {
+      meterRegistry.counter("scheduler.article.scrape.job",
+          "source", "NAVER",
+          "status", status,
+          "error_type", errorType).increment();
       sample.stop(meterRegistry.timer("scheduler.article.scrape.time",
           "source", "NAVER",
           "status", status,

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJob.java
@@ -5,6 +5,8 @@ import com.codeit.monew.global.exception.external.ExternalClientException;
 import com.codeit.monew.global.exception.external.ExternalNetworkException;
 import com.codeit.monew.global.exception.external.ExternalRateLimitException;
 import com.codeit.monew.global.exception.external.ExternalServerException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class NaverArticleBatchJob {
 
   private final NaverKeywordTxProcessor naverKeywordTxProcessor;
+  private final MeterRegistry meterRegistry;
 
   @Retryable(
       // 재시도 대상: 429에러, 서버 에러 및 네트워크 장애 (일시적 오류)
@@ -29,22 +32,42 @@ public class NaverArticleBatchJob {
       backoff = @Backoff(delay = 100, multiplier = 10)
   )
   public ArticleScrapeResult run(String keyword) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String status = "success";
+    String errorType = "none"; // 에러 유형 초기화
     try {
       ArticleScrapeResult result = naverKeywordTxProcessor.processOneKeyword(keyword);
+      if (result.totalSavedCount() > 0) {
+        meterRegistry.counter("scheduler.article.scrape.saved.total", "source", "NAVER")
+            .increment(result.totalSavedCount());
+      }
       log.info("[NAVER_BATCH] keyword='{}', saved={}", keyword, result.totalSavedCount());
       return result;
     } catch (ExternalRateLimitException e) {
+      status = "fail";
+      errorType = "RATE_LIMIT";
       log.warn("[NAVER_BATCH] keyword='{}' rate-limited(429), retrying...", keyword);
       throw e;
     } catch (ExternalClientException e) {
+      status = "fail";
+      errorType = "CLIENT_ERROR";
       log.warn("[NAVER_BATCH] keyword='{}' client error(4xx), no retry", keyword);
       throw e;
     } catch (ExternalServerException | ExternalNetworkException e) {
+      status = "fail";
+      errorType = "SERVER_ERROR";
       log.warn("[NAVER_BATCH] keyword='{}' transient failure, retrying...", keyword);
       throw e;
     } catch (Exception e) {
+      status = "fail";
+      errorType = "UNKNOWN";
       log.error("[NAVER_BATCH] keyword='{}' unexpected error", keyword, e);
       throw e;
+    } finally {
+      sample.stop(meterRegistry.timer("scheduler.article.scrape.time",
+          "source", "NAVER",
+          "status", status,
+          "error_type", errorType));
     }
   }
 

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
@@ -6,6 +6,8 @@ import com.codeit.monew.global.exception.external.ExternalNetworkException;
 import com.codeit.monew.global.exception.external.ExternalRateLimitException;
 import com.codeit.monew.global.exception.external.ExternalServerException;
 import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class RssArticleBatchJob {
 
   private final RssSourceTxProcessor rssSourceTxProcessor;
+  private final MeterRegistry meterRegistry;
 
   @Retryable(
       // 재시도 대상: 서버 에러 및 네트워크 장애 (일시적 오류)
@@ -29,22 +32,45 @@ public class RssArticleBatchJob {
       backoff = @Backoff(delayExpression = "${retry.backoff.delay:10000}", multiplier = 2)
   )
   public ArticleScrapeResult run(NewsSourceUrl source) {
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String status = "success";
+    String errorType = "none"; // 에러 유형 초기화
+    String sourceName = source.name(); // 예: CHOSUN, JOONGANG
+
     try {
       ArticleScrapeResult result = rssSourceTxProcessor.processOneSource(source);
+      if (result.totalSavedCount() > 0) {
+        meterRegistry.counter("scheduler.article.scrape.saved.total", "source", sourceName)
+            .increment(result.totalSavedCount());
+      }
+
       log.info("[RSS_BATCH] source={}, saved={}", source, result.totalSavedCount());
       return result;
     } catch (ExternalRateLimitException e) {
+      status = "fail";
+      errorType = "RATE_LIMIT";
       log.warn("[RSS_BATCH] source={} rate-limited(429), skip source", source);
       throw e;
     } catch (ExternalClientException e) {
+      status = "fail";
+      errorType = "CLIENT_ERROR";
       log.warn("[RSS_BATCH] source={} client error(4xx), skip source", source);
       throw e;
     } catch (ExternalServerException | ExternalNetworkException e) {
+      status = "fail";
+      errorType = "SERVER_ERROR";
       log.warn("[RSS_BATCH] source={} transient failure, retrying...", source);
       throw e;
     } catch (Exception e) {
+      status = "fail";
+      errorType = "UNKNOWN";
       log.error("[RSS_BATCH] source={} unexpected error", source, e);
       throw e;
+    } finally {
+      sample.stop(meterRegistry.timer("scheduler.article.scrape.time",
+          "source", sourceName,
+          "status", status,
+          "error_type", errorType));
     }
   }
 

--- a/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
+++ b/src/main/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJob.java
@@ -67,6 +67,10 @@ public class RssArticleBatchJob {
       log.error("[RSS_BATCH] source={} unexpected error", source, e);
       throw e;
     } finally {
+      meterRegistry.counter("scheduler.article.scrape.job",
+          "source", sourceName,
+          "status", status,
+          "error_type", errorType).increment();
       sample.stop(meterRegistry.timer("scheduler.article.scrape.time",
           "source", sourceName,
           "status", status,

--- a/src/main/java/com/codeit/monew/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/notification/scheduler/NotificationScheduler.java
@@ -1,18 +1,46 @@
 package com.codeit.monew.domain.notification.scheduler;
 
 import com.codeit.monew.domain.notification.service.NotificationService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationScheduler {
   private final NotificationService notificationService;
+  private final MeterRegistry meterRegistry;
 
   // 매일 새벽 0시 0분에 실행 (Cron: 초 분 시 일 월 요일)
   @Scheduled(cron = "0 0 0 * * *")
   public void runNotificationCleanUp() {
-    notificationService.cleanUpOldNotifications();
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String status = "success";
+    int deletedTotal = 0;
+    try {
+      log.info("[NOTIFICATION_DELETE] 알림 정리 작업 시작");
+      deletedTotal = notificationService.cleanUpOldNotifications();
+
+      // 삭제된 알림의 총 누적 합계를 기록
+      if (deletedTotal > 0) {
+        meterRegistry.counter("scheduler.notification.deleted.total").increment(deletedTotal);
+      }
+    } catch (Exception e) {
+      status = "fail";
+      log.error("[NOTIFICATION_DELETE] 작업 중 예외 발생", e);
+      throw e;
+    } finally {
+      // 작업 횟수 및 결과 기록
+      meterRegistry.counter("scheduler.notification.job", "status", status).increment();
+
+      // 작업 소요 시간 기록
+      sample.stop(meterRegistry.timer("scheduler.notification.job.time", "status", status));
+
+      log.info("[NOTIFICATION_DELETE] 작업 종료: 상태={}, 삭제건수={}", status, deletedTotal);
+    }
   }
 }

--- a/src/main/java/com/codeit/monew/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/notification/scheduler/NotificationScheduler.java
@@ -16,7 +16,7 @@ public class NotificationScheduler {
   private final MeterRegistry meterRegistry;
 
   // 매일 새벽 0시 0분에 실행 (Cron: 초 분 시 일 월 요일)
-  @Scheduled(cron = "0 0 0 * * *")
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   public void runNotificationCleanUp() {
     Timer.Sample sample = Timer.start(meterRegistry);
     String status = "success";

--- a/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/monew/domain/notification/service/NotificationService.java
@@ -207,10 +207,11 @@ public class NotificationService {
 
   // 확인한 알림 중 7일이 경과된 알림 삭제
   @Transactional
-  public void cleanUpOldNotifications() {
+  public int cleanUpOldNotifications() {
     Instant targetTime = Instant.now().minus(7, ChronoUnit.DAYS);
 
     int deletedCount = notificationRepository.deleteOldConfirmedNotifications(targetTime);
     log.info("[NOTIFICATION_DELETE] 7일 경과된 읽은 알림 삭제 완료: {}건", deletedCount);
+    return deletedCount;
   }
 }

--- a/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
@@ -2,6 +2,8 @@ package com.codeit.monew.domain.user.scheduler;
 
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -17,17 +19,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserScheduler {
 
   private final UserRepository userRepository;
+  private final MeterRegistry meterRegistry;
 
   //크론 표현식으로 매일 0시 0분에 실행되도록 처리
-  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")// 10초마다 실행
   @Transactional
   public void cleanUpUser() {
-    Instant threshold = Instant.now().minus(Duration.ofDays(1));
-    log.info("[USER_CLEAN_UP] 논리 삭제 후 1일 지난 사용자 삭제 스케줄러 동작: 기준 시간={}", threshold);
-    List<User> targets = userRepository.findByDeletedAtBefore(threshold);
-    log.info("[USER_CLEAN_UP] 삭제 대상 사용자 수={}", targets.size());
-    userRepository.deleteAllInBatch(targets);
-    log.info("[USER_CLEAN_UP] 물리 삭제 배치 완료");
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String status = "success";
+    int deletedCount = 0;
+
+    try {
+      Instant threshold = Instant.now().minus(Duration.ofDays(1));
+      log.info("[USER_CLEAN_UP] 논리 삭제 후 1일 지난 사용자 삭제 스케줄러 동작: 기준 시간={}", threshold);
+      List<User> targets = userRepository.findByDeletedAtBefore(threshold);
+      deletedCount = targets.size();
+      log.info("[USER_CLEAN_UP] 삭제 대상 사용자 수={}", targets.size());
+      userRepository.deleteAllInBatch(targets);
+      if (deletedCount > 0) {
+        meterRegistry.counter("scheduler.user.deleted.total").increment(deletedCount);
+      }
+    } catch (Exception e) {
+      status = "fail";
+      throw e;
+    } finally {
+      meterRegistry.counter("scheduler.user.job", "status", status).increment();
+      sample.stop(meterRegistry.timer("scheduler.user.job.time", "status", status));
+      log.info("[USER_CLEAN_UP] 스케줄러 종료: 상태={}, 삭제건수={}", status, deletedCount);
+    }
   }
 
 }

--- a/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
@@ -22,7 +22,7 @@ public class UserScheduler {
   private final MeterRegistry meterRegistry;
 
   //크론 표현식으로 매일 0시 0분에 실행되도록 처리
-  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")// 10초마다 실행
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   @Transactional
   public void cleanUpUser() {
     Timer.Sample sample = Timer.start(meterRegistry);

--- a/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/com/codeit/monew/domain/user/scheduler/UserScheduler.java
@@ -36,14 +36,19 @@ public class UserScheduler {
       deletedCount = targets.size();
       log.info("[USER_CLEAN_UP] 삭제 대상 사용자 수={}", targets.size());
       userRepository.deleteAllInBatch(targets);
+
       if (deletedCount > 0) {
+        // 삭제된 사용자의 총 누적 합계를 기록
         meterRegistry.counter("scheduler.user.deleted.total").increment(deletedCount);
       }
     } catch (Exception e) {
       status = "fail";
       throw e;
     } finally {
+      // 작업 횟수 및 결과 기록
       meterRegistry.counter("scheduler.user.job", "status", status).increment();
+
+      // 작업 소요 시간 기록
       sample.stop(meterRegistry.timer("scheduler.user.job.time", "status", status));
       log.info("[USER_CLEAN_UP] 스케줄러 종료: 상태={}, 삭제건수={}", status, deletedCount);
     }

--- a/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
+++ b/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
@@ -65,6 +65,7 @@ public class LogUploadScheduler {
             }
             case UPLOAD_FAILED -> {
               failedCount++;
+              jobStatus = "partial_fail";
               recordDetail("FAILED");
             }
           }

--- a/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
+++ b/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
@@ -1,5 +1,7 @@
 package com.codeit.monew.infra.logging;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
@@ -17,12 +19,17 @@ public class LogUploadScheduler {
 
   private final LogUploadProperties logUploadProperties;
   private final LogUploadService logUploadService;
+  private final MeterRegistry meterRegistry;
 
   /**
    * 지정된 스케줄(Cron)에 따라 로그 업로드 작업을 수행합니다.
    */
   @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
   public void uploadRecentLogs() {
+
+    Timer.Sample sample = Timer.start(meterRegistry);
+    String jobStatus = "success";
+
     // 1. 기준 시간 및 조회 기간 설정
     ZoneId zoneId = ZoneId.of(logUploadProperties.getZone());
     LocalDate baseDate = LocalDate.now(zoneId);
@@ -37,34 +44,64 @@ public class LogUploadScheduler {
     int skippedCount = 0;
     int failedCount = 0;
 
-    // 2. 1일 전부터 lookbackDays 전까지 역순으로 루프를 돌며 업로드 시도
-    for (int daysAgo = 1; daysAgo <= lookbackDays; daysAgo++) {
-      LocalDate targetDate = baseDate.minusDays(daysAgo);
+    try {
+      // 2. 1일 전부터 lookbackDays 전까지 역순으로 루프를 돌며 업로드 시도
+      for (int daysAgo = 1; daysAgo <= lookbackDays; daysAgo++) {
+        LocalDate targetDate = baseDate.minusDays(daysAgo);
 
-      try {
-        // 서비스 계층을 통해 개별 날짜 로그 업로드 실행
-        LogUploadResult result = logUploadService.uploadDailyLog(targetDate);
+        try {
+          // 서비스 계층을 통해 개별 날짜 로그 업로드 실행
+          LogUploadResult result = logUploadService.uploadDailyLog(targetDate);
 
-        // 결과 상태에 따른 통계 처리
-        switch (result.status()) {
-          case UPLOADED_TO_S3 -> uploadedCount++;
-          case SKIPPED_FILE_NOT_FOUND, SKIPPED_ALREADY_EXISTS -> skippedCount++;
-          case UPLOAD_FAILED -> failedCount++;
+          // 결과 상태에 따른 통계 처리
+          switch (result.status()) {
+            case UPLOADED_TO_S3 -> {
+              uploadedCount++;
+              recordDetail("UPLOADED");
+            }
+            case SKIPPED_FILE_NOT_FOUND, SKIPPED_ALREADY_EXISTS -> {
+              skippedCount++;
+              recordDetail("SKIPPED");
+            }
+            case UPLOAD_FAILED -> {
+              failedCount++;
+              recordDetail("FAILED");
+            }
+          }
+
+          log.info("[LOG_UPLOAD] scheduled upload processed: targetDate={}, status={}, message={}",
+              targetDate, result.status(), result.message());
+
+        } catch (Exception e) {
+          // 개별 날짜 처리 중 예외 발생 시, 전체 루프를 멈추지 않고 에러 로그 기록 후 다음 날짜로 진행
+          failedCount++;
+          recordDetail("FAILED");
+          log.error("[LOG_UPLOAD] scheduled upload failed: targetDate={}, error={}",
+              targetDate, e.getMessage(), e);
         }
-
-        log.info("[LOG_UPLOAD] scheduled upload processed: targetDate={}, status={}, message={}",
-            targetDate, result.status(), result.message());
-
-      } catch (Exception e) {
-        // 개별 날짜 처리 중 예외 발생 시, 전체 루프를 멈추지 않고 에러 로그 기록 후 다음 날짜로 진행
-        failedCount++;
-        log.error("[LOG_UPLOAD] scheduled upload failed: targetDate={}, error={}",
-            targetDate, e.getMessage(), e);
       }
+    } catch (Exception e) {
+      jobStatus = "fail"; // for 루프 자체가 붕괴되는 심각한 에러 발생 시
+      log.error("[LOG_UPLOAD] 스케줄러 전체 로직 에러", e);
+      throw e;
+    } finally {
+      // 작업 횟수 및 결과 기록
+      meterRegistry.counter("scheduler.log.upload.job", "status", jobStatus).increment();
+
+      // 작업 소요 시간 기록
+      sample.stop(meterRegistry.timer("scheduler.log.upload.job.time", "status", jobStatus));
+
+      log.info("[LOG_UPLOAD] 작업 종료: uploaded={}, skipped={}, failed={}",
+          uploadedCount, skippedCount, failedCount);
     }
 
     // 3. 전체 작업 결과 요약 출력
     log.info("[LOG_UPLOAD] scheduled upload summary: uploaded={}, skipped={}, failed={}",
         uploadedCount, skippedCount, failedCount);
+  }
+
+  // 세부 상태별 건수를 메트릭에 포함시기는 헬퍼 메서드
+  private void recordDetail(String resultStatus) {
+    meterRegistry.counter("scheduler.log.upload.detail", "result", resultStatus).increment();
   }
 }

--- a/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
+++ b/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
@@ -75,6 +75,7 @@ public class LogUploadScheduler {
         } catch (Exception e) {
           // 개별 날짜 처리 중 예외 발생 시, 전체 루프를 멈추지 않고 에러 로그 기록 후 다음 날짜로 진행
           failedCount++;
+          jobStatus = "partial_fail";
           recordDetail("FAILED");
           log.error("[LOG_UPLOAD] scheduled upload failed: targetDate={}, error={}",
               targetDate, e.getMessage(), e);

--- a/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
+++ b/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
@@ -91,13 +91,10 @@ public class LogUploadScheduler {
       // 작업 소요 시간 기록
       sample.stop(meterRegistry.timer("scheduler.log.upload.job.time", "status", jobStatus));
 
-      log.info("[LOG_UPLOAD] 작업 종료: uploaded={}, skipped={}, failed={}",
+      // 3. 전체 작업 결과 요약 출력
+      log.info("[LOG_UPLOAD] scheduled upload summary: uploaded={}, skipped={}, failed={}",
           uploadedCount, skippedCount, failedCount);
     }
-
-    // 3. 전체 작업 결과 요약 출력
-    log.info("[LOG_UPLOAD] scheduled upload summary: uploaded={}, skipped={}, failed={}",
-        uploadedCount, skippedCount, failedCount);
   }
 
   // 세부 상태별 건수를 메트릭에 포함시기는 헬퍼 메서드

--- a/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
+++ b/src/main/java/com/codeit/monew/infra/logging/LogUploadScheduler.java
@@ -30,14 +30,6 @@ public class LogUploadScheduler {
     Timer.Sample sample = Timer.start(meterRegistry);
     String jobStatus = "success";
 
-    // 1. 기준 시간 및 조회 기간 설정
-    ZoneId zoneId = ZoneId.of(logUploadProperties.getZone());
-    LocalDate baseDate = LocalDate.now(zoneId);
-
-    // 최소 1일은 조회하도록 설정
-    int lookbackDays = Math.max(1, logUploadProperties.getLookbackDays());
-
-    log.info("[LOG_UPLOAD] scheduled upload started: lookbackDays={}", lookbackDays);
 
     // 결과 통계를 위한 카운터 초기화
     int uploadedCount = 0;
@@ -45,6 +37,14 @@ public class LogUploadScheduler {
     int failedCount = 0;
 
     try {
+      // 1. 기준 시간 및 조회 기간 설정
+      ZoneId zoneId = ZoneId.of(logUploadProperties.getZone());
+      LocalDate baseDate = LocalDate.now(zoneId);
+
+      // 최소 1일은 조회하도록 설정
+      int lookbackDays = Math.max(1, logUploadProperties.getLookbackDays());
+
+      log.info("[LOG_UPLOAD] scheduled upload started: lookbackDays={}", lookbackDays);
       // 2. 1일 전부터 lookbackDays 전까지 역순으로 루프를 돌며 업로드 시도
       for (int daysAgo = 1; daysAgo <= lookbackDays; daysAgo++) {
         LocalDate targetDate = baseDate.minusDays(daysAgo);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,8 +76,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,loggers
+        include: health,info,metrics,loggers,prometheus
   endpoint:
+    prometheus:
+      access: read-only  # 또는 unconditional (버전에 따라 다를 수 있음)
+    metrics:
+      access: read-only
     health:
       show-details: never
 

--- a/src/test/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJobTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/scheduler/NaverArticleBatchJobTest.java
@@ -13,6 +13,8 @@ import com.codeit.monew.global.exception.external.ExternalNetworkException;
 import com.codeit.monew.global.exception.external.ExternalRateLimitException;
 import com.codeit.monew.global.exception.external.ExternalServerException;
 import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,8 +37,13 @@ class NaverArticleBatchJobTest {
     }
 
     @Bean
-    NaverArticleBatchJob naverArticleBatchJob(NaverKeywordTxProcessor naverKeywordTxProcessor) {
-      return new NaverArticleBatchJob(naverKeywordTxProcessor);
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Bean
+    NaverArticleBatchJob naverArticleBatchJob(NaverKeywordTxProcessor naverKeywordTxProcessor, MeterRegistry meterRegistry) {
+      return new NaverArticleBatchJob(naverKeywordTxProcessor, meterRegistry);
     }
   }
 

--- a/src/test/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJobTest.java
+++ b/src/test/java/com/codeit/monew/domain/article/scheduler/RssArticleBatchJobTest.java
@@ -13,6 +13,8 @@ import com.codeit.monew.global.exception.external.ExternalNetworkException;
 import com.codeit.monew.global.exception.external.ExternalRateLimitException;
 import com.codeit.monew.global.exception.external.ExternalServerException;
 import com.codeit.monew.infra.external.rss.NewsSourceUrl;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,8 +41,13 @@ class RssArticleBatchJobTest {
     }
 
     @Bean
-    RssArticleBatchJob rssArticleBatchJob(RssSourceTxProcessor rssSourceTxProcessor) {
-      return new RssArticleBatchJob(rssSourceTxProcessor);
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Bean
+    RssArticleBatchJob rssArticleBatchJob(RssSourceTxProcessor rssSourceTxProcessor, MeterRegistry meterRegistry) {
+      return new RssArticleBatchJob(rssSourceTxProcessor, meterRegistry);
     }
   }
 

--- a/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
+++ b/src/test/java/com/codeit/monew/domain/user/scheduler/UserSchedulerTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,6 +26,9 @@ class UserSchedulerTest {
 
   @Mock
   private UserRepository userRepository;
+
+  @Spy
+  private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @InjectMocks
   private UserScheduler userScheduler;


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) Closes #155, #162

## 📝작업 내용

- 스케줄링 작업
  - 사용자 물리 삭제
  - 오래된 알림 삭제
  - 로그 업로드
  - 기사 수집
- 위 작업에 성공/실패, 소요 시간, 합계 등 커스텀 메트릭을 추가하였습니다.

- 로컬 환경에서 프로메테우스(메트릭 데이터 수집), 그라파나(데이터 시각화 툴)을 도커 컨테이너로 띄워 작동하는 것을 확인했습니다.

- 기존 스케줄링 테스트 코드가 통과되도록 임시로 SimpleMeterRegistry를 추가하였습니다
  - 이후 메트릭 관련 테스트 코드 추가 예정

## 스크린샷
<img width="1377" height="1052" alt="화면 캡처 2026-04-28 182637" src="https://github.com/user-attachments/assets/76c9eb0c-53a9-4124-8d6d-54f319e80c33" />

 - 프로메테우스에서 현재 어플리케이션의 상태를 확인할 수 있습니다.


<img width="1389" height="1053" alt="화면 캡처 2026-04-28 182931" src="https://github.com/user-attachments/assets/2409b57b-a256-45da-8e80-c9c039b10968" />

 - 그라파나 내부 대시보드 생성 후 메트릭를 선택하여 정보를 불러올 수 있습니다.
 - 기본적으로 서버 시스템, JVM, Tomcat, DB 관련 메트릭이 제공됩니다.


<img width="1387" height="1062" alt="화면 캡처 2026-04-28 183030" src="https://github.com/user-attachments/assets/2364016b-30ec-4764-b46b-e13f120f408d" />

 - 현재 그라파나 도커 볼륨을 초기화하여 기존 내역이 날라가서 서버 cpu 사용량을 시각화하였습니다.
 - 스케줄링 작업이 1회 수행되면 자동으로 메트릭 목록에 추가됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Prometheus와 Grafana 기반 모니터링 스택 도입 및 도커 컴포즈로 제공
  * 배치·스케줄러·로그 업로드 작업에 실행 시간·상태·처리 건수 등의 자동 메트릭 수집 추가

* **기타**
  * Actuator에 prometheus 엔드포인트 노출 및 접근 제어(read-only) 설정 추가
  * Prometheus 스크래프 설정 추가, Grafana 데이터 영속화 및 관리자 암호 환경변수 지원
  * 빌드·테스트 구성에 메트릭 레지스트리 추가 (테스트용 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->