### PR TITLE
[docs] 댓글/알림 Swagger API 명세 및 알림 scheduler 테스트 코드 추가

### DIFF
--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentCursorRequest.java
@@ -1,6 +1,7 @@
 package com.codeit.monew.domain.comment.dto;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -9,8 +10,10 @@ import java.time.Instant;
 import java.util.UUID;
 
 // 댓글 목록 조회 요청 dto
+@Schema(description = "조회할 댓글 목록 정보")
 public record CommentCursorRequest(
-    @Parameter(description = "기사 ID", required = true)
+
+    @Parameter(description = "기사 ID")
     @NotNull(message = "기사 ID는 필수입니다.")
     UUID articleId,
 

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentDto.java
@@ -1,16 +1,33 @@
 package com.codeit.monew.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
 
 public record CommentDto(
+
+    @Schema(description = "댓글 ID")
     UUID id,
+
+    @Schema(description = "기사 ID")
     UUID articleId,
+
+    @Schema(description = "댓글 작성자 ID")
     UUID userId,
+
+    @Schema(description = "댓글 작성자 닉네임")
     String userNickname,
+
+    @Schema(description = "댓글 내용")
     String content,
+
+    @Schema(description = "댓글 좋아요 수")
     Long likeCount,
+
+    @Schema(description = "요청자의 좋아요 여부")
     boolean likedByMe,
+
+    @Schema(description = "작성된 날짜")
     Instant createdAt
 ) {
 }

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentLikeDto.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentLikeDto.java
@@ -1,18 +1,39 @@
 package com.codeit.monew.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
 
 public record CommentLikeDto(
+
+    @Schema(description = "좋아요 ID")
     UUID id,
+
+    @Schema(description = "좋아요한 사용자 ID")
     UUID likedBy,
+
+    @Schema(description = "좋아요한 날짜")
     Instant createdAt,
+
+    @Schema(description = "댓글 ID")
     UUID commentId,
+
+    @Schema(description = "기사 ID")
     UUID articleId,
+
+    @Schema(description = "댓글 작성자 ID")
     UUID commentUserId,
+
+    @Schema(description = "댓글 작성자 닉네임")
     String commentUserNickname,
+
+    @Schema(description = "댓글 내용")
     String commentContent,
+
+    @Schema(description = "댓글 좋아요 수")
     Long commentLikeCount,
+
+    @Schema(description = "작성된 날짜")
     Instant commentCreatedAt
 ) {
 }

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentRegisterRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentRegisterRequest.java
@@ -17,7 +17,7 @@ public record CommentRegisterRequest(
     @NotNull(message = "사용자 ID는 필수입니다.")
     UUID userId,
 
-    @Schema(description = "댓글 내용")
+    @Schema(description = "댓글 내용", maxLength = 500)
     @NotBlank(message = "댓글 내용은 필수입니다.")
     @Size(min = 1, max = 500, message = "댓글 내용은 1자 이상 500자 이하여야 합니다.")
     String content

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentRegisterRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentRegisterRequest.java
@@ -1,17 +1,23 @@
 package com.codeit.monew.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
 
+@Schema(description = "댓글 등록 정보")
 public record CommentRegisterRequest(
+
+    @Schema(description = "기사 ID")
     @NotNull(message = "기사 ID는 필수입니다.")
     UUID articleId,
 
+    @Schema(description = "요청 사용자 ID")
     @NotNull(message = "사용자 ID는 필수입니다.")
     UUID userId,
 
+    @Schema(description = "댓글 내용")
     @NotBlank(message = "댓글 내용은 필수입니다.")
     @Size(min = 1, max = 500, message = "댓글 내용은 1자 이상 500자 이하여야 합니다.")
     String content

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CommentUpdateRequest.java
@@ -1,9 +1,13 @@
 package com.codeit.monew.domain.comment.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "댓글 수정 정보")
 public record CommentUpdateRequest(
+
+    @Schema(description = "수정할 댓글 내용")
     @NotBlank(message = "댓글 내용은 필수입니다.")
     @Size(min = 1, max = 500, message = "댓글 내용은 1자 이상 500자 이하여야 합니다.")
     String content

--- a/src/main/java/com/codeit/monew/domain/comment/dto/CursorPageResponseCommentDto.java
+++ b/src/main/java/com/codeit/monew/domain/comment/dto/CursorPageResponseCommentDto.java
@@ -10,19 +10,19 @@ public record CursorPageResponseCommentDto(
     @Schema(description = "조회된 댓글 목록")
     List<CommentDto> content,
 
-    @Schema(description = "커서 값")
+    @Schema(description = "다음 페이지 커서")
     String nextCursor,
 
-    @Schema(description = "보조 커서(createdAt) 값")
+    @Schema(description = "다음 보조 커서(마지막 요소의 생성 시간)", example = "2026-04-17T15:04:05.000Z")
     Instant nextAfter,
 
-    @Schema(description = "커서 페이지 크기")
+    @Schema(description = "페이지 크기", example = "10")
     int size,
 
-    @Schema(description = "전체 데이터 개수")
+    @Schema(description = "총 요소 수", example = "100")
     long totalElements,
 
-    @Schema(description = "다음 페이지 존재 여부")
+    @Schema(description = "다음 페이지 여부", example = "true")
     boolean hasNext
 ) {
 }

--- a/src/main/java/com/codeit/monew/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/codeit/monew/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "알림 관리", description = "알림 관련 API")
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor

--- a/src/main/java/com/codeit/monew/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/codeit/monew/domain/notification/dto/NotificationDto.java
@@ -9,25 +9,25 @@ public record NotificationDto(
     @Schema(description = "알림 ID")
     UUID id,
 
-    @Schema(description = "알림 생성 일시")
+    @Schema(description = "생성된 날짜")
     Instant createdAt,
 
-    @Schema(description = "알림 수정 일시")
+    @Schema(description = "확인한 날짜")
     Instant updatedAt,
 
-    @Schema(description = "알림 확인 여부")
+    @Schema(description = "확인 여부")
     boolean confirmed,
 
-    @Schema(description = "알림을 받을 사용자 ID")
+    @Schema(description = "알림 대상 사용자 ID")
     UUID userId,
 
     @Schema(description = "알림 내용")
     String content,
 
-    @Schema(description = "관련 리소스 타입 (INTEREST 또는 COMMENT)")
+    @Schema(description = "관련 리소스 유형", allowableValues = {"interest", "comment"})
     String resourceType,
 
-    @Schema(description = "관련 리소스 ID (관심사 ID 또는 댓글 ID)")
+    @Schema(description = "관련 리소스 ID")
     UUID resourceId
 ) {
 

--- a/src/main/java/com/codeit/monew/domain/notification/dto/NotificationListDto.java
+++ b/src/main/java/com/codeit/monew/domain/notification/dto/NotificationListDto.java
@@ -1,14 +1,28 @@
 package com.codeit.monew.domain.notification.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.List;
 
+@Schema(description = "조회할 알림 목록 정보")
 public record NotificationListDto(
+
+    @Schema(description = "조회된 알림 목록")
     List<NotificationDto> content,
+
+    @Schema(description = "커서 값")
     String nextCursor,
+
+    @Schema(description = "보조 커서(createdAt) 값")
     Instant nextAfter,
+
+    @Schema(description = "커서 페이지 크기")
     int size,
+
+    @Schema(description = "전체 데이터 개수")
     long totalElements,
+
+    @Schema(description = "다음 페이지 존재 여부")
     boolean hasNext
 ) {
 

--- a/src/test/java/com/codeit/monew/domain/notification/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/codeit/monew/domain/notification/scheduler/NotificationSchedulerTest.java
@@ -1,0 +1,85 @@
+package com.codeit.monew.domain.notification.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.monew.domain.notification.service.NotificationService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+  @Mock
+  private NotificationService notificationService;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  private NotificationScheduler notificationScheduler;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    notificationScheduler = new NotificationScheduler(notificationService, meterRegistry);
+  }
+
+  @Test
+  @DisplayName("알림 정리가 성공하면 메트릭에 성공 상태와 삭제 건수가 기록된다.")
+  void runNotificationCleanUp_success() {
+    // given
+    int deletedCount = 5;
+    given(notificationService.cleanUpOldNotifications()).willReturn(deletedCount);
+
+    // when
+    notificationScheduler.runNotificationCleanUp();
+
+    // then
+    verify(notificationService, times(1)).cleanUpOldNotifications();
+    assertThat(meterRegistry.counter("scheduler.notification.deleted.total").count())
+        .isEqualTo(deletedCount); // 총 삭제 건수가 5만큼 증가했는지 검증
+    assertThat(meterRegistry.counter("scheduler.notification.job", "status", "success").count())
+        .isEqualTo(1); // 작업 상태가 success로 기록되었는지 검증
+    assertThat(meterRegistry.timer("scheduler.notification.job.time", "status", "success").count())
+        .isEqualTo(1L); // 타이머가 success 상태로 측정되었는지 검증
+  }
+
+  @Test
+  @DisplayName("삭제할 알림이 없을 경우 삭제 건수 메트릭은 증가하지 않는다.")
+  void runNotificationCleanUp_success_no_deletion() {
+    // given
+    given(notificationService.cleanUpOldNotifications()).willReturn(0);
+
+    // when
+    notificationScheduler.runNotificationCleanUp();
+
+    // then
+    assertThat(meterRegistry.find("scheduler.notification.deleted.total").counter()).isNull(); // 삭제 카운터가 생성 및 증가되지 않아야 함
+    assertThat(meterRegistry.counter("scheduler.notification.job", "status", "success").count())
+        .isEqualTo(1); // 작업 성공 여부 카운터는 정상적으로 올라가야 함
+  }
+
+  @Test
+  @DisplayName("작업 중 예외가 발생하면 fail 상태가 기록되고 예외가 던져진다.")
+  void runNotificationCleanUp_fail() {
+    // given
+    RuntimeException exception = new RuntimeException("DB Timeout");
+    given(notificationService.cleanUpOldNotifications()).willThrow(exception);
+
+    // when & then
+    assertThatThrownBy(() -> notificationScheduler.runNotificationCleanUp())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("DB Timeout");
+
+    assertThat(meterRegistry.counter("scheduler.notification.job", "status", "fail").count())
+        .isEqualTo(1); // 작업 상태가 fail로 기록되었는지 검증
+    assertThat(meterRegistry.timer("scheduler.notification.job.time", "status", "fail").count())
+        .isEqualTo(1L); // 타이머가 fail 상태로 완료되었는지 검증
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

Closes #170
Related to #138

## 📝작업 내용

- 댓글 및 알림 도메인의 dto와 controller에 누락된 Swagger API 명세를 추가하였습니다.
- 전 PR (#164)에서 빠졌던 알림 Scheduler 테스트 코드를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 댓글 및 알림 관련 API OpenAPI 스키마 주석 대폭 보강(필드 설명, 길이제한, 예시, 허용값 등 추가)
  * 일부 파라미터의 문서상 필수 표기 변경(유효성은 유지)
  * 알림 관리 API를 위한 태그 그룹화 및 설명 추가

* **Tests**
  * 알림 정리 스케줄러의 성공·0건·예외 시나리오에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->