### PR TITLE
[docs] 관심사 DTO Swagger API 문서화 작업

### DIFF
--- a/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestRegisterRequest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestRegisterRequest.java
@@ -1,15 +1,19 @@
 package com.codeit.monew.domain.interest.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
+@Schema(description = "관심사 정보")
 public record InterestRegisterRequest(
+    @Schema(description = "관심사 이름", maxLength = 50)
     @NotBlank
     @Size(max = 50)
     String name,
 
+    @Schema(description = "관심사 키워드 목록", maxLength = 10)
     @NotEmpty
     @Size(max = 10)
     List<@NotBlank String> keywords

--- a/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/request/InterestUpdateRequest.java
@@ -1,11 +1,14 @@
 package com.codeit.monew.domain.interest.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
+@Schema(description = "수정할 관심사 정보")
 public record InterestUpdateRequest(
+    @Schema(description = "수정 키워드 목록", maxLength = 10)
     @NotEmpty
     @Size(max = 10)
     List<@NotBlank String> keywords

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -14,7 +14,7 @@ public record CursorPageResponseInterestDto(
     @Schema(description = "페이지 크기", example = "10")
     int size,
 
-    @Schema(description = "총 요소 수", maxLength = 100)
+    @Schema(description = "총 요소 수", example = "100")
     long totalElements,
 
     @Schema(description = "다음 페이지 여부", example = "true")

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -1,11 +1,22 @@
 package com.codeit.monew.domain.interest.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "커서 기반 페이지 응답")
 public record CursorPageResponseInterestDto(
+    @Schema(description = "페이지 내용")
     List<InterestDto> content,
+
+    @Schema(description = "다음 페이지 커서")
     String nextCursor,
+
+    @Schema(description = "페이지 크기", example = "10")
     int size,
+
+    @Schema(description = "총 요소 수", maxLength = 100)
     long totalElements,
+
+    @Schema(description = "다음 페이지 여부", example = "true")
     boolean hasNext
 ) {}

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/InterestDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/InterestDto.java
@@ -2,15 +2,25 @@ package com.codeit.monew.domain.interest.dto.response;
 
 import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.entity.Keyword;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.UUID;
 
 // 관심사 응답
 public record InterestDto(
+    @Schema(description = "관심사 ID")
     UUID id,
+
+    @Schema(description = "관심사 이름")
     String name,
+
+    @Schema(description = "관심사 키워드 목록")
     List<String> keywords,
+
+    @Schema(description = "구독자 수")
     long subscriberCount,
+
+    @Schema(description = "요청자의 구독 여부")
     boolean subscribedByMe
 ) {
   // 등록 시 사용

--- a/src/main/java/com/codeit/monew/domain/interest/dto/response/SubscriptionDto.java
+++ b/src/main/java/com/codeit/monew/domain/interest/dto/response/SubscriptionDto.java
@@ -3,17 +3,29 @@ package com.codeit.monew.domain.interest.dto.response;
 import com.codeit.monew.domain.interest.entity.Interest;
 import com.codeit.monew.domain.interest.entity.Keyword;
 import com.codeit.monew.domain.interest.entity.Subscription;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record SubscriptionDto (
+    @Schema(description = "구독 정보 ID")
     UUID id,
+
+    @Schema(description = "관심사 ID")
     UUID interestId,
+
+    @Schema(description = "관심사 이름")
     String interestName,
+
+    @Schema(description = "관련 키워드 목록")
     List<String> interestKeywords,
+
+    @Schema(description = "구독자 수")
     long interestSubscriberCount,
+
+    @Schema(description = "구독한 날짜")
     Instant createdAt
 ) {
   public static SubscriptionDto from(Subscription subscription) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#168

## 📝작업 내용

- 관심사 DTO Swagger API 명세서 문서화 작업 진행했습니다.
- `CursorPageResponseInterestDto`의 `nextAfter`는 기능 구현 시 제외하고 진행했기 때문에 요구사항으로 받은 Swagger API 명세서와 차이가 있습니다.

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * API 문서의 요청/응답 필드 설명을 확장했습니다. 관심사 등록·수정 요청과 관심사 조회 응답(세부 항목, 페이지네이션 정보 포함), 그리고 구독 정보 응답의 각 필드에 보다 명확한 설명과 제약(길이/예시)이 추가되어 개발자 및 사용자 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->