### PR TITLE
[fix] 누락되었던 관심사 삭제 시 활동 내역 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/codeit/monew/domain/interest/service/InterestService.java
@@ -13,6 +13,7 @@ import com.codeit.monew.domain.interest.repository.KeywordRepository;
 import com.codeit.monew.domain.interest.repository.SubscriptionRepository;
 import com.codeit.monew.domain.user.entity.User;
 import com.codeit.monew.domain.user.repository.UserRepository;
+import com.codeit.monew.domain.useractivity.event.InterestDeletedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestUnSubscribedEvent;
 import com.codeit.monew.global.exception.Interest.AlreadySubscribedException;
@@ -117,6 +118,11 @@ public class InterestService {
         .orElseThrow(() -> new InterestNotFoundException(interestId));
 
     // 물리 삭제 (CASCADE로 keyword, subscription 자동 삭제)
+
+    // 활동 내역 업데이트를 위한 관심사 삭제 이벤트 발행
+    eventPublisher.publishEvent(new InterestDeletedEvent(
+        interestId
+    ));
 
     interestRepository.delete(interest);
     log.info("[INTEREST_DELETE] 관심사 삭제 완료: interestId={}", interestId);

--- a/src/main/java/com/codeit/monew/domain/useractivity/event/InterestDeletedEvent.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/event/InterestDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.codeit.monew.domain.useractivity.event;
+
+import java.util.UUID;
+
+public record InterestDeletedEvent(
+    UUID interestId
+) {
+
+}

--- a/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
@@ -131,25 +131,18 @@ public class UserActivityEventListener {
   public void handleInterestDeletedEvent(InterestDeletedEvent event) {
     log.debug("[USER_ACTIVITY] 관심사 전역 삭제 반영 시작: interestId={}", event.interestId().toString());
 
-    // DB에서 제거하기 전 해당 관심사를 가진 유저들을 검색
-    Query findQuery = new Query(Criteria.where("subscriptions.interestId").is(
-        event.interestId().toString()));
-    findQuery.fields().include("_id");
-    List<UserActivity> usersToEvict = mongoTemplate.find(findQuery, UserActivity.class);
+    // 모든 유저의 활동내역에서 관심사 제거
+    Query updateQuery = new Query(Criteria.where("subscriptions.interestId").is(event.interestId().toString()));
+    Update pullUpdate = new Update().pull("subscriptions", new Document("interestId", event.interestId().toString()));
+    mongoTemplate.updateMulti(updateQuery, pullUpdate, UserActivity.class);
 
-    // 모든 유저의 subscriptions 배열에서 해당 관심사 제거
-    Update pullUpdate = new Update().pull("subscriptions", new Document("interestId",
-        event.interestId().toString()));
-    mongoTemplate.updateMulti(findQuery, pullUpdate, UserActivity.class);
-
-    // 미리 확보한 유저 리스트를 바탕으로 캐시 무효화 진행
-    for (UserActivity user : usersToEvict) {
-      try {
-        evictUserActivityCache(UUID.fromString(user.getId()));
-      } catch (Exception e) {
-        log.warn("[USER_ACTIVITY_CACHE] 전역 삭제에 따른 캐시 무효화 실패: userId={}", user.getId());
-      }
+    Cache userActivityCache = cacheManager.getCache("userActivity");
+    if (userActivityCache == null) {
+      log.warn("[USER_ACTIVITY_CACHE] 캐시를 찾지 못해 삭제 실패");
+      return;
     }
+    userActivityCache.clear();
+
     log.info("[USER_ACTIVITY] 전역 관심사 삭제 반영 완료");
   }
 

--- a/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
+++ b/src/main/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListener.java
@@ -10,6 +10,7 @@ import com.codeit.monew.domain.useractivity.event.CommentCreatedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentLikedCancelEvent;
 import com.codeit.monew.domain.useractivity.event.CommentLikedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentUpdatedEvent;
+import com.codeit.monew.domain.useractivity.event.InterestDeletedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestUnSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.UserRegisteredEvent;
@@ -50,7 +51,7 @@ public class UserActivityEventListener {
     log.debug("[USER_ACTIVITY_CACHE] 캐시 안전 삭제 완료: userId={}", userId);
   }
 
-  // 타인들의 ID를 찾아서 캐시를 지우는 헬퍼 메서드
+  // 댓글 수정 시 연관된 타인들의 ID를 찾아서 캐시를 지우는 헬퍼 메서드
   private void queryForLikedUsers(UUID commentId) {
     Query query = new Query(Criteria.where("commentLikes.commentId").is(commentId.toString()));
     query.fields().include("_id");
@@ -123,6 +124,33 @@ public class UserActivityEventListener {
 
     evictUserActivityCache(event.userId());
     log.info("[USER_ACTIVITY] 관심사 구독 취소 완료");
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleInterestDeletedEvent(InterestDeletedEvent event) {
+    log.debug("[USER_ACTIVITY] 관심사 전역 삭제 반영 시작: interestId={}", event.interestId().toString());
+
+    // DB에서 제거하기 전 해당 관심사를 가진 유저들을 검색
+    Query findQuery = new Query(Criteria.where("subscriptions.interestId").is(
+        event.interestId().toString()));
+    findQuery.fields().include("_id");
+    List<UserActivity> usersToEvict = mongoTemplate.find(findQuery, UserActivity.class);
+
+    // 모든 유저의 subscriptions 배열에서 해당 관심사 제거
+    Update pullUpdate = new Update().pull("subscriptions", new Document("interestId",
+        event.interestId().toString()));
+    mongoTemplate.updateMulti(findQuery, pullUpdate, UserActivity.class);
+
+    // 미리 확보한 유저 리스트를 바탕으로 캐시 무효화 진행
+    for (UserActivity user : usersToEvict) {
+      try {
+        evictUserActivityCache(UUID.fromString(user.getId()));
+      } catch (Exception e) {
+        log.warn("[USER_ACTIVITY_CACHE] 전역 삭제에 따른 캐시 무효화 실패: userId={}", user.getId());
+      }
+    }
+    log.info("[USER_ACTIVITY] 전역 관심사 삭제 반영 완료");
   }
 
   @Async

--- a/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
@@ -168,34 +168,21 @@ class UserActivityEventListenerTest {
     InterestDeletedEvent event = new InterestDeletedEvent(interestId);
 
     // 캐시 삭제 대상 유저 2명 설정
-    UUID user1Id = UUID.randomUUID();
-    UUID user2Id = UUID.randomUUID();
-
-    UserActivity user1 = new UserActivity();
-    user1.setId(user1Id.toString());
-    UserActivity user2 = new UserActivity();
-    user2.setId(user2Id.toString());
 
     Query expectedQuery = new Query(Criteria.where("subscriptions.interestId").is(interestId.toString()));
-    expectedQuery.fields().include("_id");
     Update expectedUpdate = new Update().pull("subscriptions", new Document("interestId", interestId.toString()));
 
-    given(mongoTemplate.find(any(Query.class), eq(UserActivity.class))).willReturn(List.of(user1, user2));
     given(cacheManager.getCache("userActivity")).willReturn(cache);
 
     // when
     userActivityEventListener.handleInterestDeletedEvent(event);
 
     // then
-    verify(mongoTemplate).find(queryCaptor.capture(), eq(UserActivity.class));
-    verify(mongoTemplate).updateMulti(any(Query.class), updateCaptor.capture(), eq(UserActivity.class));
+    verify(mongoTemplate).updateMulti(queryCaptor.capture(), updateCaptor.capture(), eq(UserActivity.class));
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
-
-    verify(cache).evict(user1Id);
-    verify(cache).evict(user2Id);
-    verify(cache, times(2)).evict(any(UUID.class));
+    verify(cache).clear();
   }
 
   @Test

--- a/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
+++ b/src/test/java/com/codeit/monew/domain/useractivity/listener/UserActivityEventListenerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.codeit.monew.domain.article.ArticleSource;
@@ -14,6 +15,7 @@ import com.codeit.monew.domain.useractivity.event.CommentCreatedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentLikedCancelEvent;
 import com.codeit.monew.domain.useractivity.event.CommentLikedEvent;
 import com.codeit.monew.domain.useractivity.event.CommentUpdatedEvent;
+import com.codeit.monew.domain.useractivity.event.InterestDeletedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.InterestUnSubscribedEvent;
 import com.codeit.monew.domain.useractivity.event.UserRegisteredEvent;
@@ -156,6 +158,44 @@ class UserActivityEventListenerTest {
 
     assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
     assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
+  }
+
+  @Test
+  @DisplayName("관심사 삭제 이벤트 수신 시 대상 유저 조회, 전역 업데이트 및 다중 캐시 삭제가 정확히 수행되어야 한다.")
+  void should_update_multi_and_evict_multiple_caches_when_interest_deleted() {
+    // given
+    UUID interestId = UUID.randomUUID();
+    InterestDeletedEvent event = new InterestDeletedEvent(interestId);
+
+    // 캐시 삭제 대상 유저 2명 설정
+    UUID user1Id = UUID.randomUUID();
+    UUID user2Id = UUID.randomUUID();
+
+    UserActivity user1 = new UserActivity();
+    user1.setId(user1Id.toString());
+    UserActivity user2 = new UserActivity();
+    user2.setId(user2Id.toString());
+
+    Query expectedQuery = new Query(Criteria.where("subscriptions.interestId").is(interestId.toString()));
+    expectedQuery.fields().include("_id");
+    Update expectedUpdate = new Update().pull("subscriptions", new Document("interestId", interestId.toString()));
+
+    given(mongoTemplate.find(any(Query.class), eq(UserActivity.class))).willReturn(List.of(user1, user2));
+    given(cacheManager.getCache("userActivity")).willReturn(cache);
+
+    // when
+    userActivityEventListener.handleInterestDeletedEvent(event);
+
+    // then
+    verify(mongoTemplate).find(queryCaptor.capture(), eq(UserActivity.class));
+    verify(mongoTemplate).updateMulti(any(Query.class), updateCaptor.capture(), eq(UserActivity.class));
+
+    assertThat(queryCaptor.getValue()).isEqualTo(expectedQuery);
+    assertThat(updateCaptor.getValue()).isEqualTo(expectedUpdate);
+
+    verify(cache).evict(user1Id);
+    verify(cache).evict(user2Id);
+    verify(cache, times(2)).evict(any(UUID.class));
   }
 
   @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

ex) Closes #181 

## 📝작업 내용

- 관심사를 삭제해도 관심사 선택 항목에서 남아있던 문제가 발생하여 이를 해결하였습니다.
- InterestDeletedEvent를 추가하여 관심사 삭제 시 이벤트 발행 후 활동 내역에도 반영되도록 로직을 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관심사 삭제 시 모든 사용자의 구독 정보가 자동으로 업데이트됩니다.

* **테스트**
  * 관심사 삭제 이벤트 처리에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->