### PR TITLE
[fix] 배포 환경에서 로그가 UTC 기준으로 작동하는 문제 수정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,10 +8,10 @@
 
   <!-- MDC 값을 포함한 로그 패턴 설정 -->
   <property name="LOG_PATTERN"
-    value="%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%-5level) %-36logger{36} [%X{requestId} | %X{clientIp} | %X{requestMethod} | %X{requestUri}] - %msg%n"/>
+    value="%d{yy-MM-dd HH:mm:ss.SSS, Asia/Seoul} [%thread] %clr(%-5level) %-36logger{36} [%X{requestId} | %X{clientIp} | %X{requestMethod} | %X{requestUri}] - %msg%n"/>
   <springProfile name="prod">
     <property name="LOG_PATTERN"
-      value="%d{yy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%-5level) %-36logger{36} [%X{requestId} | %X{clientIp} | %X{requestMethod} | %X{requestUri}] - %maskedMsg%n"/>
+      value="%d{yy-MM-dd HH:mm:ss.SSS, Asia/Seoul} [%thread] %clr(%-5level) %-36logger{36} [%X{requestId} | %X{clientIp} | %X{requestMethod} | %X{requestUri}] - %maskedMsg%n"/>
   </springProfile>
   <property name="LOG_FILE_PATH" value=".logs"/>
   <property name="LOG_FILE_NAME" value="application"/>
@@ -30,7 +30,8 @@
       <pattern>${LOG_PATTERN}</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_FILE_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <fileNamePattern>${LOG_FILE_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd,Asia/Seoul}.log
+      </fileNamePattern>
       <maxHistory>30</maxHistory>
     </rollingPolicy>
   </appender>


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

배포 환경에서 로그가 UTC 기준으로 작동해서 시간이 안맞고, 9시에 롤링 정책이 실행되어 로그가 다음 날 백업되는 문제를 수정함.

## 📸스크린샷 (선택)
<img width="570" height="82" alt="image" src="https://github.com/user-attachments/assets/d3d14aac-1a09-40c7-b065-bbcc5fd5c24b" />


## 💬리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로깅 설정을 업데이트하였습니다. 기본 및 프로덕션 환경의 타임스탬프에 Asia/Seoul 시간대가 추가되었으며, 프로덕션 환경에서는 로그 메시지 마스킹이 적용됩니다. 로그 파일 롤오버 명명 패턴도 시간대를 포함하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->